### PR TITLE
Track visited status for NPCs/objects

### DIFF
--- a/Sku.toc
+++ b/Sku.toc
@@ -56,6 +56,7 @@ SkuMob\Core.lua
 SkuMob\Options.lua
 
 SkuNav\Core.lua
+SkuNav\Visited.lua
 SkuNav\SkuMM.lua
 SkuNav\data.lua
 SkuNav\Options.lua

--- a/SkuNav/Core.lua
+++ b/SkuNav/Core.lua
@@ -307,7 +307,10 @@ function SkuNav:CreateWaypointCache()
 
 end
 
+---------------------------------------------------------------------------------------------------------------------------------------
+-- { string -> boolean }
 local visitedWaypointsSet = {}
+-- string -> nil
 function SkuNav:setWaypointVisited(wpName)
 	-- only track visited for things players would be interested in farming, like hostile NPCs and objects
 	-- assuming if NPC has no role, then hostile, but some friendly NPCs also don't have a role, like guards
@@ -324,10 +327,13 @@ function SkuNav:setWaypointVisited(wpName)
 	end
 end
 
+---------------------------------------------------------------------------------------------------------------------------------------
+-- string -> optional<boolean>
 function SkuNav:waypointWasVisited(wpName)
 	return visitedWaypointsSet[wpName]
 end
 
+---------------------------------------------------------------------------------------------------------------------------------------
 function SkuNav:clearVisitedWaypoints()
 	visitedWaypointsSet = {}
 end

--- a/SkuNav/Core.lua
+++ b/SkuNav/Core.lua
@@ -308,8 +308,8 @@ function SkuNav:CreateWaypointCache()
 end
 
 ---------------------------------------------------------------------------------------------------------------------------------------
--- { string -> boolean }
-local visitedWaypointsSet = {}
+-- Dictionary mapping waypoint ids to last time they were visited or nil if unvisited
+local waypointVisitedDict = {}
 -- string -> nil
 function SkuNav:setWaypointVisited(wpName)
 	-- only track visited for things players would be interested in farming, like hostile NPCs and objects
@@ -323,19 +323,26 @@ function SkuNav:setWaypointVisited(wpName)
 			-- is hostile NPC
 			or (wp.typeId == 2 and wp.role == "")
 		) then
-		visitedWaypointsSet[wpName] = true
+		waypointVisitedDict[wpName] = GetServerTime()
 	end
 end
 
 ---------------------------------------------------------------------------------------------------------------------------------------
--- string -> optional<boolean>
+-- string -> boolean
 function SkuNav:waypointWasVisited(wpName)
-	return visitedWaypointsSet[wpName]
+	local lastVisited = waypointVisitedDict[wpName]
+	if lastVisited == nil then return false end
+	local timeToExpire = 5 * 60 -- 5 minutes
+	if GetServerTime() - lastVisited > timeToExpire then
+		-- visited status has expired
+		waypointVisitedDict[wpName] = nil
+		return false
+	else return true end
 end
 
 ---------------------------------------------------------------------------------------------------------------------------------------
 function SkuNav:clearVisitedWaypoints()
-	visitedWaypointsSet = {}
+	waypointVisitedDict = {}
 end
 
 ------------------------------------------------------------------------------------------------------------------------

--- a/SkuNav/Core.lua
+++ b/SkuNav/Core.lua
@@ -307,46 +307,6 @@ function SkuNav:CreateWaypointCache()
 
 end
 
----------------------------------------------------------------------------------------------------------------------------------------
--- Dictionary mapping waypoint ids to last time they were visited or nil if unvisited
-local waypointVisitedDict = {}
--- string -> nil
-function SkuNav:setWaypointVisited(wpName)
-	if not SkuOptions.db.profile[MODULE_NAME].trackVisited then return end
-	-- only track visited for things players would be interested in farming, like hostile NPCs and objects
-	-- assuming if NPC has no role, then hostile, but some friendly NPCs also don't have a role, like guards
-	-- could identify hostile creatures accurately if had access to "friendlyMask", but in SkuDB.NpcData only have access to "hostileMask" (as "factionID")
-	-- reference: https://github.com/cmangos/issues/wiki/FactionTemplate.dbc
-	local wp = SkuNav:GetWaypointData2(wpName)
-	if wp and (
-		-- is object
-		wp.typeId == 3
-			-- is hostile NPC
-			or (wp.typeId == 2 and wp.role == "")
-		) then
-		waypointVisitedDict[wpName] = GetServerTime()
-	end
-end
-
----------------------------------------------------------------------------------------------------------------------------------------
--- string -> boolean
-function SkuNav:waypointWasVisited(wpName)
-	if not SkuOptions.db.profile[MODULE_NAME].trackVisited then return false end
-	local lastVisited = waypointVisitedDict[wpName]
-	if lastVisited == nil then return false end
-	local timeToExpire = 5 * 60 -- 5 minutes
-	if GetServerTime() - lastVisited > timeToExpire then
-		-- visited status has expired
-		waypointVisitedDict[wpName] = nil
-		return false
-	else return true end
-end
-
----------------------------------------------------------------------------------------------------------------------------------------
-function SkuNav:clearVisitedWaypoints()
-	waypointVisitedDict = {}
-end
-
 ------------------------------------------------------------------------------------------------------------------------
 function SkuNav:LoadLinkDataFromProfile()
 	dprint("LoadLinkDataFromProfile")

--- a/SkuNav/Core.lua
+++ b/SkuNav/Core.lua
@@ -309,7 +309,19 @@ end
 
 local visitedWaypointsSet = {}
 function SkuNav:setWaypointVisited(wpName)
-	visitedWaypointsSet[wpName] = true
+	-- only track visited for things players would be interested in farming, like hostile NPCs and objects
+	-- assuming if NPC has no role, then hostile, but some friendly NPCs also don't have a role, like guards
+	-- could identify hostile creatures accurately if had access to "friendlyMask", but in SkuDB.NpcData only have access to "hostileMask" (as "factionID")
+	-- reference: https://github.com/cmangos/issues/wiki/FactionTemplate.dbc
+	local wp = SkuNav:GetWaypointData2(wpName)
+	if wp and (
+		-- is object
+		wp.typeId == 3
+			-- is hostile NPC
+			or (wp.typeId == 2 and wp.role == "")
+		) then
+		visitedWaypointsSet[wpName] = true
+	end
 end
 
 function SkuNav:waypointWasVisited(wpName)

--- a/SkuNav/Core.lua
+++ b/SkuNav/Core.lua
@@ -312,6 +312,7 @@ end
 local waypointVisitedDict = {}
 -- string -> nil
 function SkuNav:setWaypointVisited(wpName)
+	if not SkuOptions.db.profile[MODULE_NAME].trackVisited then return end
 	-- only track visited for things players would be interested in farming, like hostile NPCs and objects
 	-- assuming if NPC has no role, then hostile, but some friendly NPCs also don't have a role, like guards
 	-- could identify hostile creatures accurately if had access to "friendlyMask", but in SkuDB.NpcData only have access to "hostileMask" (as "factionID")
@@ -330,6 +331,7 @@ end
 ---------------------------------------------------------------------------------------------------------------------------------------
 -- string -> boolean
 function SkuNav:waypointWasVisited(wpName)
+	if not SkuOptions.db.profile[MODULE_NAME].trackVisited then return false end
 	local lastVisited = waypointVisitedDict[wpName]
 	if lastVisited == nil then return false end
 	local timeToExpire = 5 * 60 -- 5 minutes

--- a/SkuNav/Core.lua
+++ b/SkuNav/Core.lua
@@ -328,6 +328,10 @@ function SkuNav:waypointWasVisited(wpName)
 	return visitedWaypointsSet[wpName]
 end
 
+function SkuNav:clearVisitedWaypoints()
+	visitedWaypointsSet = {}
+end
+
 ------------------------------------------------------------------------------------------------------------------------
 function SkuNav:LoadLinkDataFromProfile()
 	dprint("LoadLinkDataFromProfile")

--- a/SkuNav/Core.lua
+++ b/SkuNav/Core.lua
@@ -307,6 +307,15 @@ function SkuNav:CreateWaypointCache()
 
 end
 
+local visitedWaypointsSet = {}
+function SkuNav:setWaypointVisited(wpName)
+	visitedWaypointsSet[wpName] = true
+end
+
+function SkuNav:waypointWasVisited(wpName)
+	return visitedWaypointsSet[wpName]
+end
+
 ------------------------------------------------------------------------------------------------------------------------
 function SkuNav:LoadLinkDataFromProfile()
 	dprint("LoadLinkDataFromProfile")
@@ -1616,6 +1625,9 @@ function SkuNav:ProcessCheckReachingWp()
 									SkuOptions.BeaconLib:DestroyBeacon("SkuOptions", SkuOptions.db.profile[MODULE_NAME].selectedWaypoint)
 								end
 								SkuOptions:VocalizeMultipartString(L["Arrived at target"]..";", false, true, 0.3, true)
+
+								local selectedWaypoint = SkuOptions.db.profile[MODULE_NAME].selectedWaypoint
+								SkuNav:setWaypointVisited(selectedWaypoint)
 
 								SkuOptions.db.profile[MODULE_NAME].metapathFollowing = nil
 								SkuOptions.db.profile[MODULE_NAME].metapathFollowingMetapaths = nil

--- a/SkuNav/Core.lua
+++ b/SkuNav/Core.lua
@@ -1583,6 +1583,7 @@ function SkuNav:ProcessCheckReachingWp()
 						if SkuOptions.BeaconLib:GetBeaconStatus("SkuOptions", SkuOptions.db.profile[MODULE_NAME].selectedWaypoint) then
 							SkuOptions.BeaconLib:DestroyBeacon("SkuOptions", SkuOptions.db.profile[MODULE_NAME].selectedWaypoint)
 						end
+						SkuNav:setWaypointVisited(SkuOptions.db.profile[MODULE_NAME].selectedWaypoint)
 						SkuNav:SelectWP("", true)
 					end
 				end

--- a/SkuNav/Options.lua
+++ b/SkuNav/Options.lua
@@ -288,7 +288,7 @@ end
 local function SkuNav_MenuBuilder_WaypointSelectionMenu(aParent, aSortedWaypointList)
 	--dprint("SkuNav_MenuBuilder_WaypointSelectionMenu")
 	for i, waypointName in pairs(aSortedWaypointList) do
-		local tNewMenuEntry = SkuOptions:InjectMenuItems(aParent, {waypointName}, SkuGenericMenuItem)
+		local tNewMenuEntry = SkuOptions:InjectMenuItems(aParent, {"visited" .. waypointName}, SkuGenericMenuItem)
 		tNewMenuEntry.dynamic = true
 		tNewMenuEntry.BuildChildren = function(self)
 			SkuOptions.SkuNav_MenuBuilder_WaypointSelectionMenu_NPC = nil
@@ -297,7 +297,7 @@ local function SkuNav_MenuBuilder_WaypointSelectionMenu(aParent, aSortedWaypoint
 			--select wp
 			local tNewMenuEntrySub = SkuOptions:InjectMenuItems(self, {L["Auswählen"]}, SkuGenericMenuItem)
 			tNewMenuEntrySub.OnEnter = function(self)
-				SkuOptions.SkuNav_MenuBuilder_WaypointSelectionMenu_NPC = self.parent.name
+				SkuOptions.SkuNav_MenuBuilder_WaypointSelectionMenu_NPC = waypointName
 			end
 
 			--close rts

--- a/SkuNav/Options.lua
+++ b/SkuNav/Options.lua
@@ -13,6 +13,11 @@ SkuNav.StandardWpReachedRanges = {
    [3] = L["Auto"],
 }
 
+local timeForVisitedToExpireValues = {"disabled", "1 minute"}
+for i=2, 30 do
+	timeForVisitedToExpireValues[i+1] = i .. " minutes"
+end
+
 SkuNav.options = {
 	name = MODULE_NAME,
 	type = "group",
@@ -248,6 +253,19 @@ SkuNav.options = {
 				return SkuOptions.db.profile[MODULE_NAME].trackVisited
 			end
 		},
+		timeForVisitedToExpire = {
+			order = 13,
+			name = "visited automatically expires after",
+			desc = "",
+			type = "select",
+			values = timeForVisitedToExpireValues,
+			set = function(info,val)
+				SkuOptions.db.profile[MODULE_NAME].timeForVisitedToExpire = val
+			end,
+			get = function(info)
+				return SkuOptions.db.profile[MODULE_NAME].timeForVisitedToExpire
+			end
+		},
 	}
 }
 ---------------------------------------------------------------------------------------------------------------------------------------
@@ -273,6 +291,7 @@ SkuNav.defaults = {
 	autoGlobalDirection = false,
 	showGlobalDirectionInWaypointLists = false,
 	trackVisited = true,
+	timeForVisitedToExpire = 6, -- 5 minutes
 }
 
 local slower = string.lower

--- a/SkuNav/Options.lua
+++ b/SkuNav/Options.lua
@@ -284,9 +284,9 @@ local function SkuSpairs(t, order)
 	end
 end
 
-function SkuNav:getAnnotatedWaypointLabel(originalLabel)
+function SkuNav:getAnnotatedWaypointLabel(originalLabel, id)
 	-- annotate with "visited" if visited
-	local wpID = string.sub(originalLabel, string.find(originalLabel, "#") + 1)
+	local wpID = id or string.sub(originalLabel, string.find(originalLabel, "#") + 1)
 	if SkuNav:waypointWasVisited(wpID) then
 		return "visited " .. originalLabel
 	else return originalLabel
@@ -1012,7 +1012,7 @@ function SkuNav:MenuBuilder(aParentEntry)
 									end
 									tDistText = tDistText..tDirectionTargetWp									
 
-									local tNewMenuEntry = SkuOptions:InjectMenuItems(self, { SkuNav:getAnnotatedWaypointLabel(tDistText .. "#" .. tV) }, SkuGenericMenuItem) --
+									local tNewMenuEntry = SkuOptions:InjectMenuItems(self, { SkuNav:getAnnotatedWaypointLabel(tDistText .. "#" .. tV, tV) }, SkuGenericMenuItem) --
 									tNewMenuEntry.OnEnter = function(self)
 										SkuOptions.db.profile[MODULE_NAME].metapathFollowingUnitDbWaypoint = nil
 										SkuOptions.db.profile[MODULE_NAME].metapathFollowingUnitDbWaypointData = nil

--- a/SkuNav/Options.lua
+++ b/SkuNav/Options.lua
@@ -284,7 +284,7 @@ local function SkuSpairs(t, order)
 	end
 end
 
-local function getAnnotatedWaypointLabel(originalLabel)
+function SkuNav:getAnnotatedWaypointLabel(originalLabel)
 	-- annotate with "visited" if visited
 	local wpID = string.sub(originalLabel, string.find(originalLabel, "#") + 1)
 	if SkuNav:waypointWasVisited(wpID) then
@@ -297,7 +297,7 @@ end
 local function SkuNav_MenuBuilder_WaypointSelectionMenu(aParent, aSortedWaypointList)
 	--dprint("SkuNav_MenuBuilder_WaypointSelectionMenu")
 	for i, waypointName in pairs(aSortedWaypointList) do
-		local tNewMenuEntry = SkuOptions:InjectMenuItems(aParent, {getAnnotatedWaypointLabel(waypointName)}, SkuGenericMenuItem)
+		local tNewMenuEntry = SkuOptions:InjectMenuItems(aParent, {SkuNav:getAnnotatedWaypointLabel(waypointName)}, SkuGenericMenuItem)
 		tNewMenuEntry.dynamic = true
 		tNewMenuEntry.BuildChildren = function(self)
 			SkuOptions.SkuNav_MenuBuilder_WaypointSelectionMenu_NPC = nil
@@ -1012,7 +1012,7 @@ function SkuNav:MenuBuilder(aParentEntry)
 									end
 									tDistText = tDistText..tDirectionTargetWp									
 
-									local tNewMenuEntry = SkuOptions:InjectMenuItems(self, { getAnnotatedWaypointLabel(tDistText .. "#" .. tV) }, SkuGenericMenuItem) --
+									local tNewMenuEntry = SkuOptions:InjectMenuItems(self, { SkuNav:getAnnotatedWaypointLabel(tDistText .. "#" .. tV) }, SkuGenericMenuItem) --
 									tNewMenuEntry.OnEnter = function(self)
 										SkuOptions.db.profile[MODULE_NAME].metapathFollowingUnitDbWaypoint = nil
 										SkuOptions.db.profile[MODULE_NAME].metapathFollowingUnitDbWaypointData = nil

--- a/SkuNav/Options.lua
+++ b/SkuNav/Options.lua
@@ -700,6 +700,12 @@ function SkuNav:MenuBuilder(aParentEntry)
 			end
 		end
 
+		local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {L["Clear visited"]}, SkuGenericMenuItem)
+	tNewMenuEntry.OnAction = function(self, aValue, aName)
+		SkuNav:clearVisitedWaypoints()
+		PlaySound(835)
+	end
+
 		local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {L["Verwalten"]}, SkuGenericMenuItem)
 		tNewMenuEntry.dynamic = true
 		tNewMenuEntry.BuildChildren = function(self)

--- a/SkuNav/Options.lua
+++ b/SkuNav/Options.lua
@@ -284,14 +284,20 @@ local function SkuSpairs(t, order)
 	end
 end
 
+local function getAnnotatedWaypointLabel(originalLabel)
+	-- annotate with "visited" if visited
+	local wpID = string.sub(originalLabel, string.find(originalLabel, "#") + 1)
+	if SkuNav:waypointWasVisited(wpID) then
+		return "visited " .. originalLabel
+	else return originalLabel
+	end
+end
+
 ---------------------------------------------------------------------------------------------------------------------------------------
 local function SkuNav_MenuBuilder_WaypointSelectionMenu(aParent, aSortedWaypointList)
 	--dprint("SkuNav_MenuBuilder_WaypointSelectionMenu")
-	for i, waypointInfo in pairs(aSortedWaypointList) do
-		local wpLabel = waypointInfo.name
-		if SkuNav:waypointWasVisited(waypointInfo.id) then wpLabel = "visited"..wpLabel end
-
-		local tNewMenuEntry = SkuOptions:InjectMenuItems(aParent, {wpLabel}, SkuGenericMenuItem)
+	for i, waypointName in pairs(aSortedWaypointList) do
+		local tNewMenuEntry = SkuOptions:InjectMenuItems(aParent, {getAnnotatedWaypointLabel(waypointName)}, SkuGenericMenuItem)
 		tNewMenuEntry.dynamic = true
 		tNewMenuEntry.BuildChildren = function(self)
 			SkuOptions.SkuNav_MenuBuilder_WaypointSelectionMenu_NPC = nil
@@ -300,7 +306,7 @@ local function SkuNav_MenuBuilder_WaypointSelectionMenu(aParent, aSortedWaypoint
 			--select wp
 			local tNewMenuEntrySub = SkuOptions:InjectMenuItems(self, {L["Auswählen"]}, SkuGenericMenuItem)
 			tNewMenuEntrySub.OnEnter = function(self)
-				SkuOptions.SkuNav_MenuBuilder_WaypointSelectionMenu_NPC = waypointInfo.name
+				SkuOptions.SkuNav_MenuBuilder_WaypointSelectionMenu_NPC = waypointName
 			end
 
 			--close rts
@@ -352,7 +358,7 @@ local function SkuNav_MenuBuilder_WaypointSelectionMenu(aParent, aSortedWaypoint
 										tDirectionTargetWp = ";"..tDirectionString
 									end
 								end	
-
+																
 								if (tMetapaths[tNearWps[x].wpName].distance / SkuNav.BestRouteWeightedLengthModForMetaDistance) + tDistToEndTargetWp < tBestRouteWeightedLength then
 									tBestRouteWeightedLength = (tMetapaths[tNearWps[x].wpName].distance / SkuNav.BestRouteWeightedLengthModForMetaDistance) + tDistToEndTargetWp
 									tResults[wpName] = {
@@ -609,13 +615,7 @@ function SkuNav:MenuBuilder(aParentEntry)
 
 				local tSortedWaypointList = {}
 				for k,v in SkuSpairs(tWaypointList, function(t,a,b) return t[b].distance > t[a].distance end) do --nach wert
-					table.insert(
-						tSortedWaypointList, 
-						{
-							id = k,
-							name = v.distance..L[";Meter"]..v.direction.."#"..k,
-						}
-					)
+					table.insert(tSortedWaypointList, v.distance..L[";Meter"]..v.direction.."#"..k)
 				end
 				if #tSortedWaypointList == 0 then
 					local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {L["Empty;list"]}, SkuGenericMenuItem)

--- a/SkuNav/Options.lua
+++ b/SkuNav/Options.lua
@@ -374,10 +374,7 @@ local function SkuNav_MenuBuilder_WaypointSelectionMenu(aParent, aSortedWaypoint
 						end
 					end
 
-					local tNewMenuGeneralSort = SkuOptions:InjectMenuItems(self, {L["By distance"]}, SkuGenericMenuItem)
-					tNewMenuGeneralSort.dynamic = true
-					tNewMenuGeneralSort.filterable = true
-					tNewMenuGeneralSort.BuildChildren = function(self)
+					do -- build choice
 						local tSortedList = {}
 						for k,v in SkuSpairs(tResults, function(t,a,b) return t[b].weightedDistance > t[a].weightedDistance end) do
 							table.insert(tSortedList, k)
@@ -397,31 +394,6 @@ local function SkuNav_MenuBuilder_WaypointSelectionMenu(aParent, aSortedWaypoint
 							end
 						end
 					end
-
-					local tNewMenuGeneralSort = SkuOptions:InjectMenuItems(self, {L["Nach Name"]}, SkuGenericMenuItem)
-					tNewMenuGeneralSort.dynamic = true
-					tNewMenuGeneralSort.filterable = true
-					tNewMenuGeneralSort.BuildChildren = function(self) 
-						local tSortedWaypointList = {}
-						for k,v in SkuSpairs(tResults) do
-							table.insert(tSortedWaypointList, k)
-						end
-						if #tSortedWaypointList == 0 then
-							local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {L["Empty;list"]}, SkuGenericMenuItem)
-						else
-							for tK, tV in ipairs(tSortedWaypointList) do
-								local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {tV.."#"..tResults[tV].metapathLength..";"..L["plus"]..";"..tResults[tV].distanceTargetWp..L[";Meter"]..tResults[tV].direction}, SkuGenericMenuItem)
-								tNewMenuEntry.OnEnter = function(self, aValue, aName)
-									SkuOptions.db.profile["SkuNav"].metapathFollowingTarget = tResults[tV].metarouteIndex
-									SkuOptions.db.profile["SkuNav"].metapathFollowingEndTarget = tResults[tV].targetWpName
-									SkuOptions.SkuNav_MenuBuilder_WaypointSelectionMenu_CloseRoute = true
-								end
-								tCoveredWps[tV] = true
-								--tHasContent = true
-							end
-						end
-					end
-										
 				end			
 
 			end

--- a/SkuNav/Options.lua
+++ b/SkuNav/Options.lua
@@ -81,7 +81,7 @@ SkuNav.options = {
 				return SkuOptions.db.profile[MODULE_NAME].includeDefaultTaxiWaypoints
 			end
 		},
-]]		
+		]]		
 		beaconVolume = {
 			order = 2,
 			name = L["Beacon Volume"],
@@ -236,6 +236,18 @@ SkuNav.options = {
 				return SkuOptions.db.profile[MODULE_NAME].showGlobalDirectionInWaypointLists
 			end
 		},
+		trackVisited = {
+			order = 12,
+			name = "Track whether waypoints were visited",
+			desc = "",
+			type = "toggle",
+			set = function(info,val)
+				SkuOptions.db.profile[MODULE_NAME].trackVisited = val
+			end,
+			get = function(info)
+				return SkuOptions.db.profile[MODULE_NAME].trackVisited
+			end
+		},
 	}
 }
 ---------------------------------------------------------------------------------------------------------------------------------------
@@ -260,6 +272,7 @@ SkuNav.defaults = {
 	clickClackSoundset = "beep",
 	autoGlobalDirection = false,
 	showGlobalDirectionInWaypointLists = false,
+	trackVisited = true,
 }
 
 local slower = string.lower

--- a/SkuNav/Options.lua
+++ b/SkuNav/Options.lua
@@ -284,6 +284,8 @@ local function SkuSpairs(t, order)
 	end
 end
 
+---------------------------------------------------------------------------------------------------------------------------------------
+-- (string, optional<string>) -> string
 function SkuNav:getAnnotatedWaypointLabel(originalLabel, id)
 	-- annotate with "visited" if visited
 	local wpID = id or string.sub(originalLabel, string.find(originalLabel, "#") + 1)

--- a/SkuNav/Options.lua
+++ b/SkuNav/Options.lua
@@ -1012,7 +1012,7 @@ function SkuNav:MenuBuilder(aParentEntry)
 									end
 									tDistText = tDistText..tDirectionTargetWp									
 
-									local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {tDistText.."#"..tV}, SkuGenericMenuItem)--
+									local tNewMenuEntry = SkuOptions:InjectMenuItems(self, { getAnnotatedWaypointLabel(tDistText .. "#" .. tV) }, SkuGenericMenuItem) --
 									tNewMenuEntry.OnEnter = function(self)
 										SkuOptions.db.profile[MODULE_NAME].metapathFollowingUnitDbWaypoint = nil
 										SkuOptions.db.profile[MODULE_NAME].metapathFollowingUnitDbWaypointData = nil

--- a/SkuNav/Options.lua
+++ b/SkuNav/Options.lua
@@ -287,8 +287,11 @@ end
 ---------------------------------------------------------------------------------------------------------------------------------------
 local function SkuNav_MenuBuilder_WaypointSelectionMenu(aParent, aSortedWaypointList)
 	--dprint("SkuNav_MenuBuilder_WaypointSelectionMenu")
-	for i, waypointName in pairs(aSortedWaypointList) do
-		local tNewMenuEntry = SkuOptions:InjectMenuItems(aParent, {"visited" .. waypointName}, SkuGenericMenuItem)
+	for i, waypointInfo in pairs(aSortedWaypointList) do
+		local wpLabel = waypointInfo.name
+		if SkuNav:waypointWasVisited(waypointInfo.id) then wpLabel = "visited"..wpLabel end
+
+		local tNewMenuEntry = SkuOptions:InjectMenuItems(aParent, {wpLabel}, SkuGenericMenuItem)
 		tNewMenuEntry.dynamic = true
 		tNewMenuEntry.BuildChildren = function(self)
 			SkuOptions.SkuNav_MenuBuilder_WaypointSelectionMenu_NPC = nil
@@ -297,7 +300,7 @@ local function SkuNav_MenuBuilder_WaypointSelectionMenu(aParent, aSortedWaypoint
 			--select wp
 			local tNewMenuEntrySub = SkuOptions:InjectMenuItems(self, {L["Auswählen"]}, SkuGenericMenuItem)
 			tNewMenuEntrySub.OnEnter = function(self)
-				SkuOptions.SkuNav_MenuBuilder_WaypointSelectionMenu_NPC = waypointName
+				SkuOptions.SkuNav_MenuBuilder_WaypointSelectionMenu_NPC = waypointInfo.name
 			end
 
 			--close rts
@@ -349,7 +352,7 @@ local function SkuNav_MenuBuilder_WaypointSelectionMenu(aParent, aSortedWaypoint
 										tDirectionTargetWp = ";"..tDirectionString
 									end
 								end	
-																
+
 								if (tMetapaths[tNearWps[x].wpName].distance / SkuNav.BestRouteWeightedLengthModForMetaDistance) + tDistToEndTargetWp < tBestRouteWeightedLength then
 									tBestRouteWeightedLength = (tMetapaths[tNearWps[x].wpName].distance / SkuNav.BestRouteWeightedLengthModForMetaDistance) + tDistToEndTargetWp
 									tResults[wpName] = {
@@ -606,7 +609,13 @@ function SkuNav:MenuBuilder(aParentEntry)
 
 				local tSortedWaypointList = {}
 				for k,v in SkuSpairs(tWaypointList, function(t,a,b) return t[b].distance > t[a].distance end) do --nach wert
-					table.insert(tSortedWaypointList, v.distance..L[";Meter"]..v.direction.."#"..k)
+					table.insert(
+						tSortedWaypointList, 
+						{
+							id = k,
+							name = v.distance..L[";Meter"]..v.direction.."#"..k,
+						}
+					)
 				end
 				if #tSortedWaypointList == 0 then
 					local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {L["Empty;list"]}, SkuGenericMenuItem)

--- a/SkuNav/Visited.lua
+++ b/SkuNav/Visited.lua
@@ -1,0 +1,42 @@
+local MODULE_NAME = "SkuNav"
+local L = Sku.L
+
+---------------------------------------------------------------------------------------------------------------------------------------
+-- Dictionary mapping waypoint ids to last time they were visited or nil if unvisited
+local waypointVisitedDict = {}
+-- string -> nil
+function SkuNav:setWaypointVisited(wpName)
+	if not SkuOptions.db.profile[MODULE_NAME].trackVisited then return end
+	-- only track visited for things players would be interested in farming, like hostile NPCs and objects
+	-- assuming if NPC has no role, then hostile, but some friendly NPCs also don't have a role, like guards
+	-- could identify hostile creatures accurately if had access to "friendlyMask", but in SkuDB.NpcData only have access to "hostileMask" (as "factionID")
+	-- reference: https://github.com/cmangos/issues/wiki/FactionTemplate.dbc
+	local wp = SkuNav:GetWaypointData2(wpName)
+	if wp and (
+		-- is object
+		wp.typeId == 3
+			-- is hostile NPC
+			or (wp.typeId == 2 and wp.role == "")
+		) then
+		waypointVisitedDict[wpName] = GetServerTime()
+	end
+end
+
+---------------------------------------------------------------------------------------------------------------------------------------
+-- string -> boolean
+function SkuNav:waypointWasVisited(wpName)
+	if not SkuOptions.db.profile[MODULE_NAME].trackVisited then return false end
+	local lastVisited = waypointVisitedDict[wpName]
+	if lastVisited == nil then return false end
+	local timeToExpire = 5 * 60 -- 5 minutes
+	if GetServerTime() - lastVisited > timeToExpire then
+		-- visited status has expired
+		waypointVisitedDict[wpName] = nil
+		return false
+	else return true end
+end
+
+---------------------------------------------------------------------------------------------------------------------------------------
+function SkuNav:clearVisitedWaypoints()
+	waypointVisitedDict = {}
+end

--- a/SkuNav/Visited.lua
+++ b/SkuNav/Visited.lua
@@ -28,7 +28,9 @@ function SkuNav:waypointWasVisited(wpName)
 	if not SkuOptions.db.profile[MODULE_NAME].trackVisited then return false end
 	local lastVisited = waypointVisitedDict[wpName]
 	if lastVisited == nil then return false end
-	local timeToExpire = 5 * 60 -- 5 minutes
+	local timeToExpire = (SkuOptions.db.profile[MODULE_NAME].timeForVisitedToExpire - 1) * 60
+	-- 0 = refresh disabled
+	if timeToExpire == 0 then return true end
 	if GetServerTime() - lastVisited > timeToExpire then
 		-- visited status has expired
 		waypointVisitedDict[wpName] = nil

--- a/SkuQuest/Options.lua
+++ b/SkuQuest/Options.lua
@@ -523,7 +523,7 @@ local function CreateRtWpSubmenu(aParent, aSubIDTable, aSubType, aQuestID)
 											end
 											tDistText = tDistText..tDirectionTargetWp
 
-											local tNewMenuEntry = SkuOptions:InjectMenuItems(self, { SkuNav:getAnnotatedWaypointLabel(tDistText .. "#" .. tV) }, SkuGenericMenuItem)
+											local tNewMenuEntry = SkuOptions:InjectMenuItems(self, { SkuNav:getAnnotatedWaypointLabel(tDistText .. "#" .. tV, tV) }, SkuGenericMenuItem)
 											tNewMenuEntry.OnEnter = function(self, aValue, aName)
 												SkuOptions.db.profile["SkuNav"].metapathFollowingTarget = tV
 											end
@@ -573,7 +573,7 @@ local function CreateRtWpSubmenu(aParent, aSubIDTable, aSubType, aQuestID)
 									end
 									tDistText = tDistText..tDirectionTargetWp
 
-									local tNewMenuEntry = SkuOptions:InjectMenuItems(self, { SkuNav:getAnnotatedWaypointLabel(tDistText .. "#" .. tV) }, SkuGenericMenuItem)
+									local tNewMenuEntry = SkuOptions:InjectMenuItems(self, { SkuNav:getAnnotatedWaypointLabel(tDistText .. "#" .. tV, tV) }, SkuGenericMenuItem)
 									tNewMenuEntry.OnEnter = function(self, aValue, aName)
 										SkuOptions.db.profile["SkuNav"].metapathFollowingTarget = tV
 									end
@@ -685,7 +685,7 @@ local function CreateRtWpSubmenu(aParent, aSubIDTable, aSubType, aQuestID)
 								local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {L["Empty;list"]}, SkuGenericMenuItem)
 							else
 								for tK, tV in ipairs(tSortedList) do
-									local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {tResults[tV].metapathLength..";"..L["plus"]..";"..tResults[tV].distanceTargetWp..L[";Meter"]..tResults[tV].direction.."#"..tV}, SkuGenericMenuItem)
+									local tNewMenuEntry = SkuOptions:InjectMenuItems(self, { SkuNav:getAnnotatedWaypointLabel(tResults[tV].metapathLength .. ";" .. L["plus"] .. ";" .. tResults[tV].distanceTargetWp .. L[";Meter"] .. tResults[tV].direction .. "#" .. tV, tV) }, SkuGenericMenuItem)
 									tNewMenuEntry.OnEnter = function(self, aValue, aName)
 										SkuOptions.db.profile["SkuNav"].metapathFollowingTarget = tResults[tV].metarouteIndex
 										SkuOptions.db.profile["SkuNav"].metapathFollowingEndTarget = tResults[tV].targetWpName
@@ -708,7 +708,7 @@ local function CreateRtWpSubmenu(aParent, aSubIDTable, aSubType, aQuestID)
 								local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {L["Empty;list"]}, SkuGenericMenuItem)
 							else
 								for tK, tV in ipairs(tSortedWaypointList) do
-									local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {tV.."#"..tResults[tV].metapathLength..";"..L["plus"]..";"..tResults[tV].distanceTargetWp..L[";Meter"]..tResults[tV].direction}, SkuGenericMenuItem)
+									local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {SkuNav:getAnnotatedWaypointLabel(tV.."#"..tResults[tV].metapathLength..";"..L["plus"]..";"..tResults[tV].distanceTargetWp..L[";Meter"]..tResults[tV].direction, tV)}, SkuGenericMenuItem)
 									tNewMenuEntry.OnEnter = function(self, aValue, aName)
 										SkuOptions.db.profile["SkuNav"].metapathFollowingTarget = tResults[tV].metarouteIndex
 										SkuOptions.db.profile["SkuNav"].metapathFollowingEndTarget = tResults[tV].targetWpName
@@ -777,7 +777,7 @@ local function CreateRtWpSubmenu(aParent, aSubIDTable, aSubType, aQuestID)
 							local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {L["Empty;list"]}, SkuGenericMenuItem)
 						else
 							for tK, tV in ipairs(tSortedList) do
-								local tNewMenuGeneralSp = SkuOptions:InjectMenuItems(self, {tResults[tV].distance..L[";Meter"]..tResults[tV].direction.."#"..tV}, SkuGenericMenuItem)
+								local tNewMenuGeneralSp = SkuOptions:InjectMenuItems(self, {SkuNav:getAnnotatedWaypointLabel(tResults[tV].distance..L[";Meter"]..tResults[tV].direction.."#"..tV, tV)}, SkuGenericMenuItem)
 								tNewMenuGeneralSp.OnEnter = function(self, aValue, aName)
 									SkuOptions.db.profile["SkuNav"].menuFollowTargetWaypoint = tV
 								end
@@ -817,7 +817,7 @@ local function CreateRtWpSubmenu(aParent, aSubIDTable, aSubType, aQuestID)
 							local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {L["Empty;list"]}, SkuGenericMenuItem)
 						else
 							for tK, tV in ipairs(tSortedList) do
-								local tNewMenuGeneralSp = SkuOptions:InjectMenuItems(self, {tV.."#"..tResults[tV].distance..L[";Meter"]..tResults[tV].direction}, SkuGenericMenuItem)
+								local tNewMenuGeneralSp = SkuOptions:InjectMenuItems(self, {SkuNav:getAnnotatedWaypointLabel(tV.."#"..tResults[tV].distance..L[";Meter"]..tResults[tV].direction, tV)}, SkuGenericMenuItem)
 								tNewMenuGeneralSp.OnEnter = function(self, aValue, aName)
 									SkuOptions.db.profile["SkuNav"].menuFollowTargetWaypoint = tV
 								end

--- a/SkuQuest/Options.lua
+++ b/SkuQuest/Options.lua
@@ -431,6 +431,7 @@ local function CreateRtWpSubmenu(aParent, aSubIDTable, aSubType, aQuestID)
 				local tNewMenuSubEntry1 = SkuOptions:InjectMenuItems(self, {L["Route"]}, SkuGenericMenuItem)
 				tNewMenuSubEntry1.dynamic = true
 				tNewMenuSubEntry1.isSelect = true
+				tNewMenuSubEntry1.filterable = true
 				tNewMenuSubEntry1.OnAction = function(self, aValue, aName)
 					--print("Route onaction", self, aValue, aName)
 					if SkuOptions.db.profile["SkuNav"].routeRecording == true then
@@ -484,11 +485,7 @@ local function CreateRtWpSubmenu(aParent, aSubIDTable, aSubType, aQuestID)
 						SkuOptions.db.profile["SkuNav"].metapathFollowingMetapaths = tMetapaths
 						SkuOptions.db.profile["SkuNav"].metapathFollowingTarget = nil
 
-								
-						local tNewMenuGeneralSort = SkuOptions:InjectMenuItems(self, {L["By distance"]}, SkuGenericMenuItem)
-						tNewMenuGeneralSort.dynamic = true
-						tNewMenuGeneralSort.filterable = true
-						tNewMenuGeneralSort.BuildChildren = function(self)
+						do -- build route choices
 							local tData = {}
 							for i, v in pairs(tMetapaths) do
 								for wpIndex, wpName in pairs(wpTable) do
@@ -534,60 +531,13 @@ local function CreateRtWpSubmenu(aParent, aSubIDTable, aSubType, aQuestID)
 								end
 							end
 						end
-						local tNewMenuGeneralSort = SkuOptions:InjectMenuItems(self, {L["By name"]}, SkuGenericMenuItem)
-						tNewMenuGeneralSort.dynamic = true
-						tNewMenuGeneralSort.filterable = true
-						tNewMenuGeneralSort.BuildChildren = function(self)
-							local tRoutesList = {}
-
-							for v, i in pairs(tMetapaths) do
-								for wpIndex, wpName in pairs(wpTable) do
-									if string.find(v, wpName) then
-										--print("find:", v, wpName)
-										tRoutesList[v] = v
-									end
-								end
-							end
-
-							local tSortedWaypointList = {}
-							for k,v in SkuSpairs(tRoutesList) do
-								table.insert(tSortedWaypointList, k)
-							end
-							if #tSortedWaypointList == 0 then
-								local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {L["Empty;list"]}, SkuGenericMenuItem)
-							else
-								for tK, tV in ipairs(tSortedWaypointList) do
-									local tDistText = tMetapaths[tV].distance..L[";Meter"]
-									if tMetapaths[tV].distance >= SkuNav.MaxMetaRange then
-										tDistText = L["weit"]
-									end
-									
-									-- add direction to wp
-									local tDirectionTargetWp = ""
-									if SkuOptions.db.profile["SkuNav"].showGlobalDirectionInWaypointLists == true then
-										local tWpData = SkuNav:GetWaypointData2(tV)
-										local tDirectionString = SkuNav:GetDirectionToAsString(tWpData.worldX, tWpData.worldY)
-										if tDirectionString then
-											tDirectionTargetWp = ";"..tDirectionString
-										end
-									end
-									tDistText = tDistText..tDirectionTargetWp
-
-									local tNewMenuEntry = SkuOptions:InjectMenuItems(self, { SkuNav:getAnnotatedWaypointLabel(tDistText .. "#" .. tV, tV) }, SkuGenericMenuItem)
-									tNewMenuEntry.OnEnter = function(self, aValue, aName)
-										SkuOptions.db.profile["SkuNav"].metapathFollowingTarget = tV
-									end
-									tCoveredWps[tV] = true
-									--tHasContent = true
-								end
-							end
-						end						
 					end
 				end
-			
+
 				local tNewMenuSubEntry1 = SkuOptions:InjectMenuItems(self, {L["Closest route"]}, SkuGenericMenuItem)
 				tNewMenuSubEntry1.dynamic = true
 				tNewMenuSubEntry1.isSelect = true
+				tNewMenuSubEntry1.filterable = true
 				tNewMenuSubEntry1.OnAction = function(self, aValue, aName)
 					--dprint("OnAction", self.name, aValue, aName)
 					if SkuOptions.db.profile["SkuNav"].routeRecording == true then
@@ -673,10 +623,7 @@ local function CreateRtWpSubmenu(aParent, aSubIDTable, aSubType, aQuestID)
 							end
 						end
 
-						local tNewMenuGeneralSort = SkuOptions:InjectMenuItems(self, {L["By distance"]}, SkuGenericMenuItem)
-						tNewMenuGeneralSort.dynamic = true
-						tNewMenuGeneralSort.filterable = true
-						tNewMenuGeneralSort.BuildChildren = function(self)
+						do -- build choices
 							local tSortedList = {}
 							for k,v in SkuSpairs(tResults, function(t,a,b) return t[b].weightedDistance > t[a].weightedDistance end) do
 								table.insert(tSortedList, k)
@@ -695,35 +642,13 @@ local function CreateRtWpSubmenu(aParent, aSubIDTable, aSubType, aQuestID)
 								end
 							end
 						end
-
-						local tNewMenuGeneralSort = SkuOptions:InjectMenuItems(self, {L["Nach Name"]}, SkuGenericMenuItem)
-						tNewMenuGeneralSort.dynamic = true
-						tNewMenuGeneralSort.filterable = true
-						tNewMenuGeneralSort.BuildChildren = function(self)
-							local tSortedWaypointList = {}
-							for k,v in SkuSpairs(tResults) do
-								table.insert(tSortedWaypointList, k)
-							end
-							if #tSortedWaypointList == 0 then
-								local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {L["Empty;list"]}, SkuGenericMenuItem)
-							else
-								for tK, tV in ipairs(tSortedWaypointList) do
-									local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {SkuNav:getAnnotatedWaypointLabel(tV.."#"..tResults[tV].metapathLength..";"..L["plus"]..";"..tResults[tV].distanceTargetWp..L[";Meter"]..tResults[tV].direction, tV)}, SkuGenericMenuItem)
-									tNewMenuEntry.OnEnter = function(self, aValue, aName)
-										SkuOptions.db.profile["SkuNav"].metapathFollowingTarget = tResults[tV].metarouteIndex
-										SkuOptions.db.profile["SkuNav"].metapathFollowingEndTarget = tResults[tV].targetWpName
-									end
-									tCoveredWps[tV] = true
-									--tHasContent = true
-								end
-							end
-						end						
 					end
 				end
 			
 				local tNewMenuSubEntry1 = SkuOptions:InjectMenuItems(self, {L["Wegpunkt"]}, SkuGenericMenuItem)
 				tNewMenuSubEntry1.dynamic = true
 				tNewMenuSubEntry1.isSelect = true
+				tNewMenuSubEntry1.filterable = true
 				tNewMenuSubEntry1.OnAction = function(self, aValue, aName)
 					--dprint("OnAction Wegpunkt auswählen", self.name, aValue, aName)
 					if SkuOptions.db.profile[MODULE_NAME].routeRecording == true then
@@ -746,10 +671,7 @@ local function CreateRtWpSubmenu(aParent, aSubIDTable, aSubType, aQuestID)
 
 				end
 				tNewMenuSubEntry1.BuildChildren = function(self)
-					local tNewMenuGeneralSort = SkuOptions:InjectMenuItems(self, {L["By distance"]}, SkuGenericMenuItem)
-					tNewMenuGeneralSort.dynamic = true
-					tNewMenuGeneralSort.filterable = true
-					tNewMenuGeneralSort.BuildChildren = function(self)
+					do -- build choices
 						local tPlayX, tPlayY = UnitPosition("player")
 
 						local tResults = {}
@@ -785,47 +707,6 @@ local function CreateRtWpSubmenu(aParent, aSubIDTable, aSubType, aQuestID)
 							end
 						end
 					end
-					local tNewMenuGeneralSort = SkuOptions:InjectMenuItems(self, {L["Nach Name"]}, SkuGenericMenuItem)
-					tNewMenuGeneralSort.dynamic = true
-					tNewMenuGeneralSort.filterable = true
-					tNewMenuGeneralSort.BuildChildren = function(self)
-						SkuOptions.SkuNav_MenuBuilder_WaypointSelectionMenu_CloseRoute = nil
-						local tPlayX, tPlayY = UnitPosition("player")
-
-						local tResults = {}
-						for wpIndex, wpName in pairs(wpTable) do
-							local tWpObj = SkuNav:GetWaypointData2(wpName)
-							local tDistanceTargetWp = SkuNav:Distance(tPlayX, tPlayY, tWpObj.worldX, tWpObj.worldY)
-
-							-- add direction to wp
-							local tDirectionTargetWp = ""
-							if SkuOptions.db.profile["SkuNav"].showGlobalDirectionInWaypointLists == true then
-								local tDirectionString = SkuNav:GetDirectionToAsString(tWpObj.worldX, tWpObj.worldY)
-								if tDirectionString then
-									tDirectionTargetWp = ";"..tDirectionString
-								end
-							end
-
-							tResults[wpName] = {wpName = wpName, distance = tDistanceTargetWp, direction = tDirectionTargetWp,}							
-						end
-
-						local tSortedList = {}
-						for k,v in SkuSpairs(tResults, function(t,a,b) return b > a end) do
-							table.insert(tSortedList, k)
-						end
-						if #tSortedList == 0 then
-							local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {L["Empty;list"]}, SkuGenericMenuItem)
-						else
-							for tK, tV in ipairs(tSortedList) do
-								local tNewMenuGeneralSp = SkuOptions:InjectMenuItems(self, {SkuNav:getAnnotatedWaypointLabel(tV.."#"..tResults[tV].distance..L[";Meter"]..tResults[tV].direction, tV)}, SkuGenericMenuItem)
-								tNewMenuGeneralSp.OnEnter = function(self, aValue, aName)
-									SkuOptions.db.profile["SkuNav"].menuFollowTargetWaypoint = tV
-								end
-								--tHasContent = true
-							end
-						end
-					end
-
 				end
 			end
 		end
@@ -1383,7 +1264,7 @@ function SkuQuest:MenuBuilder(aParentEntry)
 		tNewMenuSubEntry.dynamic = true
 		tNewMenuSubEntry.filterable = true
 		tNewMenuSubEntry.OnAction = function(self, aValue, aName)
-			--SkuOptions.db:SetProfile(aName)
+			--SkuOptions.db:SetSProfile(aName)
 		end
 		tNewMenuSubEntry.BuildChildren = function(self)
 			local tNameCache = {}

--- a/SkuQuest/Options.lua
+++ b/SkuQuest/Options.lua
@@ -523,7 +523,7 @@ local function CreateRtWpSubmenu(aParent, aSubIDTable, aSubType, aQuestID)
 											end
 											tDistText = tDistText..tDirectionTargetWp
 
-											local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {tDistText.."#"..tV}, SkuGenericMenuItem)
+											local tNewMenuEntry = SkuOptions:InjectMenuItems(self, { SkuNav:getAnnotatedWaypointLabel(tDistText .. "#" .. tV) }, SkuGenericMenuItem)
 											tNewMenuEntry.OnEnter = function(self, aValue, aName)
 												SkuOptions.db.profile["SkuNav"].metapathFollowingTarget = tV
 											end
@@ -573,7 +573,7 @@ local function CreateRtWpSubmenu(aParent, aSubIDTable, aSubType, aQuestID)
 									end
 									tDistText = tDistText..tDirectionTargetWp
 
-									local tNewMenuEntry = SkuOptions:InjectMenuItems(self, {tDistText.."#"..tV}, SkuGenericMenuItem)
+									local tNewMenuEntry = SkuOptions:InjectMenuItems(self, { SkuNav:getAnnotatedWaypointLabel(tDistText .. "#" .. tV) }, SkuGenericMenuItem)
 									tNewMenuEntry.OnEnter = function(self, aValue, aName)
 										SkuOptions.db.profile["SkuNav"].metapathFollowingTarget = tV
 									end


### PR DESCRIPTION
- Test changing waypoint name menu item
- Track visited and display in waypoint menu
- Only track visited for hostiles and objects
- Extract out annotating label with visited
- Annotate routes with visited
- Annotate routes with visited for quest log
- Add optional id parameter to annotation helper
