### PR TITLE
all item bag menu

### DIFF
--- a/SkuCore/LocalMenu.lua
+++ b/SkuCore/LocalMenu.lua
@@ -277,6 +277,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 	local tCurrentParentContainer = nil
 	local tBagResults = {}
 	local inventoryTooltipTextCache = {}
+	local allBagItems = {}
 
 	for frameNo = 1, 8 do
 		for itemNo = 1, 36 do
@@ -418,6 +419,8 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 						end
 						
 						table.insert(tBagResults[bagId].childs, aParentChilds[bagItemSlotName])
+						table.insert(allBagItems, aParentChilds[bagItemSlotName]	)
+						allBagItems[aParentChilds[bagItemSlotName]] = aParentChilds[bagItemSlotName]
 
 					end
 				end
@@ -430,6 +433,20 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 			table.insert(v.obj.childs, vc)
 			v.obj.childs[vc] = vc
 		end
+	end
+
+	-- all items menu item
+	do
+		local allItemsMenuItemName = "all items"
+		table.insert(aParentChilds, 1, allItemsMenuItemName)
+		aParentChilds[allItemsMenuItemName] = {
+			RoC = "Child",
+			type = "Button",
+			textFirstLine = allItemsMenuItemName,
+			textFull = "",
+			noMenuNumbers = true,
+			childs = allBagItems,
+		}
 	end
 
 

--- a/SkuCore/LocalMenu.lua
+++ b/SkuCore/LocalMenu.lua
@@ -322,6 +322,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 								textFull = "",
 								noMenuNumbers = true,
 								childs = {},
+								isNewItem = C_NewItems.IsNewItem(bagId - 1, slotId),
 							}   
 							local bagItemButton = aParentChilds[bagItemSlotName]
 							--get the onclick func if there is one
@@ -418,8 +419,9 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 						end
 						
 						table.insert(tBagResultsByBag[bagId].childs, aParentChilds[bagItemSlotName])
+						-- if the item slot isn't empty, add it to allBagResults
 						if not string.find(aParentChilds[bagItemSlotName].textFirstLine, L["Empty"]) then
-							-- put a copy in all items that doesn't include the numbering in the textFirstLine
+							-- create a copy that doesn't have the numbering in textFirstLine
 							copy = {}
 							for k, v in pairs(aParentChilds[bagItemSlotName]) do
 								copy[k] = v
@@ -442,11 +444,22 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 		end
 	end
 
-	-- sort all items alphabetically
+	-- sort all items alphabetically, putting newly acquired on top
 	table.sort(allBagResults, function(item1, item2)
+		if item1.isNewItem and not item2.isNewItem then
+			return true
+		elseif item2.isNewItem and not item1.isNewItem then
+			return false
+		end
 		return item1.textFirstLine < item2.textFirstLine
 	end)
 
+	-- prepend "new" to all new items
+	for _, itemButton in pairs(allBagResults) do
+		if itemButton.isNewItem then
+			itemButton.textFirstLine = L["New"] .. " " .. itemButton.textFirstLine
+		end
+	end
 	-- all items menu item
 	do
 		local allItemsMenuItemName = "all items"

--- a/SkuCore/LocalMenu.lua
+++ b/SkuCore/LocalMenu.lua
@@ -417,7 +417,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 
 						end
 						
-						tBagResults[bagId].childs[#tBagResults[bagId].childs + 1] = aParentChilds[bagItemSlotName]
+						table.insert(tBagResults[bagId].childs, aParentChilds[bagItemSlotName])
 
 					end
 				end

--- a/SkuCore/LocalMenu.lua
+++ b/SkuCore/LocalMenu.lua
@@ -292,21 +292,21 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 							tCurrentBag = bagId
 							if not tBagResults[bagId] then
 
-								local tFriendlyName = L["Bag"].." "..bagId
+								local bagName = L["Bag"] .. " " .. bagId
 								local tText, tFullText = L["Bag"].." "..bagId, ""
-								table.insert(aParentChilds, tFriendlyName)
-								aParentChilds[tFriendlyName] = {
+								table.insert(aParentChilds, bagName)
+								aParentChilds[bagName] = {
 									frameName = containerFrameName,
 									RoC = "Child",
 									type = "Button",
 									obj = containerFrame,
-									textFirstLine = tFriendlyName,
+									textFirstLine = bagName,
 									textFull = "",
 									noMenuNumbers = true,
 									childs = {},
 								}   
 
-								tBagResults[bagId] = {obj = aParentChilds[tFriendlyName], childs = {}}
+								tBagResults[bagId] = { obj = aParentChilds[bagName], childs = {} }
 							end
 						end
 

--- a/SkuCore/LocalMenu.lua
+++ b/SkuCore/LocalMenu.lua
@@ -461,7 +461,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 	end
 	-- all items menu item
 	do
-		local allItemsMenuItemName = "all items"
+		local allItemsMenuItemName = L["all items"]
 		table.insert(aParentChilds, 1, allItemsMenuItemName)
 		aParentChilds[allItemsMenuItemName] = {
 			RoC = "Child",

--- a/SkuCore/LocalMenu.lua
+++ b/SkuCore/LocalMenu.lua
@@ -275,9 +275,9 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 	local tEmptyCounter = 1
 	local tCurrentBag
 	local tCurrentParentContainer = nil
-	local tBagResults = {}
+	local allBagResults = {}
+	local tBagResultsByBag = {}
 	local inventoryTooltipTextCache = {}
-	local allBagItems = {}
 
 	for frameNo = 1, 8 do
 		for itemNo = 1, 36 do
@@ -291,7 +291,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 
 						if bagId > 0 then
 							tCurrentBag = bagId
-							if not tBagResults[bagId] then
+							if not tBagResultsByBag[bagId] then
 
 								local bagName = L["Bag"] .. " " .. bagId
 								table.insert(aParentChilds, bagName)
@@ -306,7 +306,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 									childs = {},
 								}   
 
-								tBagResults[bagId] = { obj = aParentChilds[bagName], childs = {} }
+								tBagResultsByBag[bagId] = { obj = aParentChilds[bagName], childs = {} }
 							end
 						end
 
@@ -395,7 +395,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 							end
 							if bagItemButton and string.find(containerFrameName, "ContainerFrame") then
 								if bagItemButton.textFirstLine then
-									bagItemButton.textFirstLine = (#tBagResults[bagId].childs + 1) .. " " .. bagItemButton.textFirstLine
+									bagItemButton.textFirstLine = (#tBagResultsByBag[bagId].childs + 1) .. " " .. bagItemButton.textFirstLine
 									tEmptyCounter = tEmptyCounter + 1
 								end
 							end
@@ -417,7 +417,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 
 						end
 						
-						table.insert(tBagResults[bagId].childs, aParentChilds[bagItemSlotName])
+						table.insert(tBagResultsByBag[bagId].childs, aParentChilds[bagItemSlotName])
 						if not string.find(aParentChilds[bagItemSlotName].textFirstLine, L["Empty"]) then
 							-- put a copy in all items that doesn't include the numbering in the textFirstLine
 							copy = {}
@@ -425,8 +425,8 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 								copy[k] = v
 							end
 							copy.textFirstLine = string.sub(copy.textFirstLine, string.find(copy.textFirstLine, " ") + 1)
-							table.insert(allBagItems, copy)
-							allBagItems[copy] = copy
+							table.insert(allBagResults, copy)
+							allBagResults[copy] = copy
 						end
 
 					end
@@ -435,7 +435,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 		end  
 	end
 
-	for i, v in pairs(tBagResults) do
+	for i, v in pairs(tBagResultsByBag) do
 		for ic, vc in pairs(v.childs) do
 			table.insert(v.obj.childs, vc)
 			v.obj.childs[vc] = vc
@@ -443,7 +443,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 	end
 
 	-- sort all items alphabetically
-	table.sort(allBagItems, function(item1, item2)
+	table.sort(allBagResults, function(item1, item2)
 		return item1.textFirstLine < item2.textFirstLine
 	end)
 
@@ -456,7 +456,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 			type = "Button",
 			textFirstLine = allItemsMenuItemName,
 			noMenuNumbers = true,
-			childs = allBagItems,
+			childs = allBagResults,
 		}
 	end
 

--- a/SkuCore/LocalMenu.lua
+++ b/SkuCore/LocalMenu.lua
@@ -310,10 +310,10 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 							end
 						end
 
-						local tFriendlyName = L["Bag"]..bagId.."-"..slotId
+						local bagItemSlotName = L["Bag"] .. bagId .. "-" .. slotId
 						local tText, tFullText = L["Empty"], ""
 						if containerFrame:IsEnabled() == true then
-							aParentChilds[tFriendlyName] = {
+							aParentChilds[bagItemSlotName] = {
 								frameName = containerFrameName,
 								RoC = "Child",
 								type = "Button",
@@ -323,60 +323,61 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 								noMenuNumbers = true,
 								childs = {},
 							}   
+							local bagItemButton = aParentChilds[bagItemSlotName]
 							--get the onclick func if there is one
-							if aParentChilds[tFriendlyName].obj:IsMouseClickEnabled() == true then
-								if aParentChilds[tFriendlyName].obj:GetObjectType() == "Button" then
-									aParentChilds[tFriendlyName].func = aParentChilds[tFriendlyName].obj:GetScript("OnClick")
+							if bagItemButton.obj:IsMouseClickEnabled() == true then
+								if bagItemButton.obj:GetObjectType() == "Button" then
+									bagItemButton.func = bagItemButton.obj:GetScript("OnClick")
 								end
-								aParentChilds[tFriendlyName].containerFrameName = containerFrameName
-								aParentChilds[tFriendlyName].onActionFunc = function(self, aTable, aChildName)
+								bagItemButton.containerFrameName = containerFrameName
+								bagItemButton.onActionFunc = function(self, aTable, aChildName)
 
 								end
-								if aParentChilds[tFriendlyName].func then
-									aParentChilds[tFriendlyName].click = true
+								if bagItemButton.func then
+									bagItemButton.click = true
 								end
 							end
 
 
-							local maybeText = getItemTooltipTextFromBagItem(aParentChilds[tFriendlyName].obj:GetParent():GetID(), aParentChilds[tFriendlyName].obj:GetID())
+							local maybeText = getItemTooltipTextFromBagItem(bagItemButton.obj:GetParent():GetID(), bagItemButton.obj:GetID())
 							if maybeText then
 									local tText = maybeText
 									
-									if aParentChilds[tFriendlyName].obj.info then
-										if aParentChilds[tFriendlyName].obj.info.id then
-											aParentChilds[tFriendlyName].itemId = aParentChilds[tFriendlyName].obj.info.id
-											aParentChilds[tFriendlyName].textFirstLine = ItemName_helper(tText)
-											aParentChilds[tFriendlyName].textFull = SkuCore:AuctionPriceHistoryData(aParentChilds[tFriendlyName].obj.info.id, true, true)
+								if bagItemButton.obj.info then
+									if bagItemButton.obj.info.id then
+										bagItemButton.itemId = bagItemButton.obj.info.id
+										bagItemButton.textFirstLine = ItemName_helper(tText)
+										bagItemButton.textFull = SkuCore:AuctionPriceHistoryData(bagItemButton.obj.info.id, true, true)
 										end
 									end
-									if not aParentChilds[tFriendlyName].textFull then
-										aParentChilds[tFriendlyName].textFull = {}
+								if not bagItemButton.textFull then
+									bagItemButton.textFull = {}
 									end
 									local tFirst, tFull = ItemName_helper(tText)
-									aParentChilds[tFriendlyName].textFirstLine = tFirst
-									if type(aParentChilds[tFriendlyName].textFull) ~= "table" then
-										aParentChilds[tFriendlyName].textFull = {(aParentChilds[tFriendlyName].textFull or aParentChilds[tFriendlyName].textFirstLine or ""),}
+								bagItemButton.textFirstLine = tFirst
+								if type(bagItemButton.textFull) ~= "table" then
+									bagItemButton.textFull = { (bagItemButton.textFull or bagItemButton.textFirstLine or ""), }
 									end
-									table.insert(aParentChilds[tFriendlyName].textFull, 1, tFull)
-								local itemId = aParentChilds[tFriendlyName].itemId
+								table.insert(bagItemButton.textFull, 1, tFull)
+								local itemId = bagItemButton.itemId
 								if itemId and IsEquippableItem(itemId) then
 									local comparisnSections = getItemComparisnSections(itemId, inventoryTooltipTextCache)
 									if comparisnSections then
 										for i, section in ipairs(comparisnSections) do
 											local sectionHeader = #comparisnSections > 1 and L["currently equipped"].." "..i.."\r\n" or L["currently equipped"].."\r\n"
-											table.insert(aParentChilds[tFriendlyName].textFull, i + 1, sectionHeader .. section)
+											table.insert(bagItemButton.textFull, i + 1, sectionHeader .. section)
 										end
 									end
 								end
 							end
 
-							if aParentChilds[tFriendlyName].textFirstLine == "" and aParentChilds[tFriendlyName].textFull == "" and aParentChilds[tFriendlyName].obj.ShowTooltip then
+							if bagItemButton.textFirstLine == "" and bagItemButton.textFull == "" and bagItemButton.obj.ShowTooltip then
 								GameTooltip:ClearLines()
-								aParentChilds[tFriendlyName].obj:ShowTooltip()
+								bagItemButton.obj:ShowTooltip()
 								if TooltipLines_helper(GameTooltip:GetRegions()) ~= "asd" then
 									if TooltipLines_helper(GameTooltip:GetRegions()) ~= "" then
 										local tText = unescape(TooltipLines_helper(GameTooltip:GetRegions()))
-										aParentChilds[tFriendlyName].textFirstLine, aParentChilds[tFriendlyName].textFull = ItemName_helper(tText)
+										bagItemButton.textFirstLine, bagItemButton.textFull = ItemName_helper(tText)
 									end
 								end
 							end
@@ -384,39 +385,39 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 							
 
 							if _G[containerFrameName .. "Count"] and not containerFrame.info then
-								if aParentChilds[tFriendlyName] and _G[containerFrameName .. "Count"]:GetText() then
-									if not string.find(aParentChilds[tFriendlyName].textFirstLine, L["Empty"].." ") then
-										aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine .. " " .. _G[containerFrameName .. "Count"]:GetText()
+								if bagItemButton and _G[containerFrameName .. "Count"]:GetText() then
+									if not string.find(bagItemButton.textFirstLine, L["Empty"] .. " ") then
+										bagItemButton.textFirstLine = bagItemButton.textFirstLine .. " " .. _G[containerFrameName .. "Count"]:GetText()
 									else
-										aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine
+										bagItemButton.textFirstLine = bagItemButton.textFirstLine
 									end
 								end
 							end
-							if aParentChilds[tFriendlyName] and string.find(containerFrameName, "ContainerFrame") then
-								if aParentChilds[tFriendlyName].textFirstLine then
-									aParentChilds[tFriendlyName].textFirstLine = (#tBagResults[bagId].childs + 1).." "..aParentChilds[tFriendlyName].textFirstLine
+							if bagItemButton and string.find(containerFrameName, "ContainerFrame") then
+								if bagItemButton.textFirstLine then
+									bagItemButton.textFirstLine = (#tBagResults[bagId].childs + 1) .. " " .. bagItemButton.textFirstLine
 									tEmptyCounter = tEmptyCounter + 1
 								end
 							end
-							if _G[containerFrameName .. "Count"] and aParentChilds[tFriendlyName] then
-								aParentChilds[tFriendlyName].stackSize = _G[containerFrameName .. "Count"]:GetText()
+							if _G[containerFrameName .. "Count"] and bagItemButton then
+								bagItemButton.stackSize = _G[containerFrameName .. "Count"]:GetText()
 							end
 							if containerFrame.info then
-								aParentChilds[tFriendlyName].itemId = containerFrame.info.id
+								bagItemButton.itemId = containerFrame.info.id
 								if not containerFrame.info.count then
-									aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine
+									bagItemButton.textFirstLine = bagItemButton.textFirstLine
 								else
-									if not string.find(aParentChilds[tFriendlyName].textFirstLine, L["Empty"] .. " ") and containerFrame.info.count > 1 then
-										aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine .. " " .. containerFrame.info.count
+									if not string.find(bagItemButton.textFirstLine, L["Empty"] .. " ") and containerFrame.info.count > 1 then
+										bagItemButton.textFirstLine = bagItemButton.textFirstLine .. " " .. containerFrame.info.count
 									else
-										aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine
+										bagItemButton.textFirstLine = bagItemButton.textFirstLine
 									end
 								end								
 							end							
 
 						end
 						
-						tBagResults[bagId].childs[#tBagResults[bagId].childs + 1] = aParentChilds[tFriendlyName]
+						tBagResults[bagId].childs[#tBagResults[bagId].childs + 1] = aParentChilds[bagItemSlotName]
 
 					end
 				end

--- a/SkuCore/LocalMenu.lua
+++ b/SkuCore/LocalMenu.lua
@@ -396,6 +396,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 							end
 							if bagItemButton and string.find(containerFrameName, "ContainerFrame") then
 								if bagItemButton.textFirstLine then
+									bagItemButton.originalTextFirstLine = bagItemButton.textFirstLine
 									bagItemButton.textFirstLine = (#tBagResults[bagId].childs + 1) .. " " .. bagItemButton.textFirstLine
 									tEmptyCounter = tEmptyCounter + 1
 								end
@@ -437,6 +438,11 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 		end
 	end
 
+	-- sort all items alphabetically
+	table.sort(allBagItems, function(item1, item2)
+		return item1.originalTextFirstLine < item2.originalTextFirstLine
+	end)
+	
 	-- all items menu item
 	do
 		local allItemsMenuItemName = "all items"

--- a/SkuCore/LocalMenu.lua
+++ b/SkuCore/LocalMenu.lua
@@ -16,7 +16,7 @@ local escapes = {
 	["{.-}"] = "", -- raid target icons
 }
 local function unescape(str)
-   if not str then return end
+	if not str then return end
 	for k, v in pairs(escapes) do
 		str = string.gsub(str, k, v)
 	end
@@ -50,72 +50,72 @@ local function ItemName_helper(aText)
 		tShort = taTextWoLb
 	end
 
-   tShort = string.gsub(tShort, "\r\n", " ")
-   tShort = string.gsub(tShort, "\n", " ")
+	tShort = string.gsub(tShort, "\r\n", " ")
+	tShort = string.gsub(tShort, "\n", " ")
 	return tShort, tLong
 end
 
 ---------------------------------------------------------------------------------------------------------------------------------------
 local function GetButtonTooltipLines(aButtonObj)
-   GameTooltip:ClearLines()
-   if aButtonObj.type then
-      if aButtonObj.type ~= "" then
-         if aButtonObj:GetScript("OnEnter") then
-            aButtonObj:GetScript("OnEnter")(aButtonObj)
-         end
-      end
-   end
+	GameTooltip:ClearLines()
+	if aButtonObj.type then
+		if aButtonObj.type ~= "" then
+			if aButtonObj:GetScript("OnEnter") then
+				aButtonObj:GetScript("OnEnter")(aButtonObj)
+			end
+		end
+	end
 
-   local tQualityString = nil
+	local tQualityString = nil
 	local itemName, ItemLink = GameTooltip:GetItem()
 	if ItemLink then
-      for x = 0, #ITEM_QUALITY_COLORS do
-         local tItemCol = ITEM_QUALITY_COLORS[x].color:GenerateHexColor()
-         if tItemCol == "ffa334ee" then 
-            tItemCol = "ffa335ee"
-         end
-         if string.find(ItemLink, tItemCol) then
-            if _G["ITEM_QUALITY"..x.."_DESC"] then
-               tQualityString = _G["ITEM_QUALITY"..x.."_DESC"]
-            end
-         end
-      end
-   end
+		for x = 0, #ITEM_QUALITY_COLORS do
+			local tItemCol = ITEM_QUALITY_COLORS[x].color:GenerateHexColor()
+			if tItemCol == "ffa334ee" then 
+				tItemCol = "ffa335ee"
+			end
+			if string.find(ItemLink, tItemCol) then
+				if _G["ITEM_QUALITY"..x.."_DESC"] then
+					tQualityString = _G["ITEM_QUALITY"..x.."_DESC"]
+				end
+			end
+		end
+	end
 
 
 	local tTooltipText = ""
-   for i = 1, select("#", GameTooltip:GetRegions()) do
+	for i = 1, select("#", GameTooltip:GetRegions()) do
 		local region = select(i, GameTooltip:GetRegions())
 		if region and region:GetObjectType() == "FontString" then
 			local text = region:GetText() -- string or nil
 			if text then
-            if i == 1 and tQualityString and SkuOptions.db.profile["SkuCore"].itemSettings.ShowItemQality == true then
-               tTooltipText = tTooltipText..text.." ("..tQualityString..")\r\n"
-            else
-				   tTooltipText = tTooltipText..text.."\r\n"
-            end
+				if i == 1 and tQualityString and SkuOptions.db.profile["SkuCore"].itemSettings.ShowItemQality == true then
+					tTooltipText = tTooltipText..text.." ("..tQualityString..")\r\n"
+				else
+					tTooltipText = tTooltipText..text.."\r\n"
+				end
 
 			end
 		end
 	end
 
-   GameTooltip:SetOwner(UIParent, "Center")
-   GameTooltip:Hide()
-   if aButtonObj:GetScript("OnLeave") then
-      aButtonObj:GetScript("OnLeave")(aButtonObj)
-   end
-   
-   if tTooltipText ~= "asd" then
-      if tTooltipText ~= "" then
-         tTooltipText = unescape(tTooltipText)
-         if tTooltipText then
-            local tText, tTextf = ItemName_helper(tTooltipText)
-            return tText, tTextf
-         end
-      end
-   end
+	GameTooltip:SetOwner(UIParent, "Center")
+	GameTooltip:Hide()
+	if aButtonObj:GetScript("OnLeave") then
+		aButtonObj:GetScript("OnLeave")(aButtonObj)
+	end
+	
+	if tTooltipText ~= "asd" then
+		if tTooltipText ~= "" then
+			tTooltipText = unescape(tTooltipText)
+			if tTooltipText then
+				local tText, tTextf = ItemName_helper(tTooltipText)
+				return tText, tTextf
+			end
+		end
+	end
 
-   return "", ""
+	return "", ""
 end
 
 ---------------------------------------------------------------------------------------------------------------------------------------
@@ -205,9 +205,9 @@ local function getItemComparisnSections(itemId, cache)
 		end
 	end
 
-   if not invSlotsToCompare then
-      return
-   end
+	if not invSlotsToCompare then
+		return
+	end
 
 	local comparisnSections = {}
 	for _, slot in pairs(invSlotsToCompare) do
@@ -224,36 +224,36 @@ end
 ---------------------------------------------------------------------------------------------------------------------------------------
 function SkuCore:Build_BagnonGuildFrame(aParentChilds)
 
-   if not BagnonGuildFrame1.bagGroup then
-      BagnonGuildFrame.bagToggle:Click()
-   end
+	if not BagnonGuildFrame1.bagGroup then
+		BagnonGuildFrame.bagToggle:Click()
+	end
 
 
-   for x = 1, 10 do
-      local name, icon, isViewable, canDeposit, numWithdrawals, remainingWithdrawals, filtered = GetGuildBankTabInfo(x)
+	for x = 1, 10 do
+		local name, icon, isViewable, canDeposit, numWithdrawals, remainingWithdrawals, filtered = GetGuildBankTabInfo(x)
 
-      if name and isViewable and isViewable == true then
-         local tFriendlyName = name
-         local tText, tFullText = name, ""
-         table.insert(aParentChilds, tFriendlyName)
-         aParentChilds[tFriendlyName] = {
-            frameName = "GuildBankTab"..x,
-            RoC = "Child",
-            type = "Button",
-            obj = _G["GuildBankTab"..x],
-            textFirstLine = tFriendlyName,
-            textFull = "",
-            noMenuNumbers = true,
-            childs = {},
-            onActionFunc = function()
-               SetCurrentGuildBankTab(x) 
-               print(x)
-            end,
-            click = true,            
-         }   
-      end
-   end
-   
+		if name and isViewable and isViewable == true then
+			local tFriendlyName = name
+			local tText, tFullText = name, ""
+			table.insert(aParentChilds, tFriendlyName)
+			aParentChilds[tFriendlyName] = {
+				frameName = "GuildBankTab"..x,
+				RoC = "Child",
+				type = "Button",
+				obj = _G["GuildBankTab"..x],
+				textFirstLine = tFriendlyName,
+				textFull = "",
+				noMenuNumbers = true,
+				childs = {},
+				onActionFunc = function()
+					SetCurrentGuildBankTab(x) 
+					print(x)
+				end,
+				click = true,            
+			}   
+		end
+	end
+	
 
 
 end
@@ -261,16 +261,16 @@ end
 ---------------------------------------------------------------------------------------------------------------------------------------
 function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 
-   if not BagnonInventoryFrame1.bagGroup then
-      BagnonInventoryFrame1.bagToggle:Click()
-   end
+	if not BagnonInventoryFrame1.bagGroup then
+		BagnonInventoryFrame1.bagToggle:Click()
+	end
 
-   local dtc = { BagnonInventoryFrame1.bagGroup:GetChildren() }
-   if dtc[6] then
-      if dtc[6]:GetChecked() == true then
-         dtc[6]:Click(dtc[6])
-      end
-   end
+	local dtc = { BagnonInventoryFrame1.bagGroup:GetChildren() }
+	if dtc[6] then
+		if dtc[6]:GetChecked() == true then
+			dtc[6]:Click(dtc[6])
+		end
+	end
 
 	local tEmptyCounter = 1
 	local tCurrentBag
@@ -288,54 +288,54 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 						local bagId = containerFrame:GetBag() + 1
 						local slotId = containerFrame:GetID()
 
-                  if bagId > 0 then
-                     tCurrentBag = bagId
-                     if not tBagResults[bagId] then
+						if bagId > 0 then
+							tCurrentBag = bagId
+							if not tBagResults[bagId] then
 
-                        local tFriendlyName = L["Bag"].." "..bagId
-                        local tText, tFullText = L["Bag"].." "..bagId, ""
-                        table.insert(aParentChilds, tFriendlyName)
-                        aParentChilds[tFriendlyName] = {
-                           frameName = containerFrameName,
-                           RoC = "Child",
-                           type = "Button",
-                           obj = containerFrame,
-                           textFirstLine = tFriendlyName,
-                           textFull = "",
-                           noMenuNumbers = true,
-                           childs = {},
-                        }   
+								local tFriendlyName = L["Bag"].." "..bagId
+								local tText, tFullText = L["Bag"].." "..bagId, ""
+								table.insert(aParentChilds, tFriendlyName)
+								aParentChilds[tFriendlyName] = {
+									frameName = containerFrameName,
+									RoC = "Child",
+									type = "Button",
+									obj = containerFrame,
+									textFirstLine = tFriendlyName,
+									textFull = "",
+									noMenuNumbers = true,
+									childs = {},
+								}   
 
-                        tBagResults[bagId] = {obj = aParentChilds[tFriendlyName], childs = {}}
-                     end
-                  end
+								tBagResults[bagId] = {obj = aParentChilds[tFriendlyName], childs = {}}
+							end
+						end
 
-                  local tFriendlyName = L["Bag"]..bagId.."-"..slotId
-                  local tText, tFullText = L["Empty"], ""
-                  if containerFrame:IsEnabled() == true then
-                     aParentChilds[tFriendlyName] = {
-                        frameName = containerFrameName,
-                        RoC = "Child",
-                        type = "Button",
-                        obj = containerFrame,
-                        textFirstLine = tText,
-                        textFull = "",
-                        noMenuNumbers = true,
-                        childs = {},
-                     }   
-                     --get the onclick func if there is one
-                     if aParentChilds[tFriendlyName].obj:IsMouseClickEnabled() == true then
-                        if aParentChilds[tFriendlyName].obj:GetObjectType() == "Button" then
-                           aParentChilds[tFriendlyName].func = aParentChilds[tFriendlyName].obj:GetScript("OnClick")
-                        end
-                        aParentChilds[tFriendlyName].containerFrameName = containerFrameName
-                        aParentChilds[tFriendlyName].onActionFunc = function(self, aTable, aChildName)
+						local tFriendlyName = L["Bag"]..bagId.."-"..slotId
+						local tText, tFullText = L["Empty"], ""
+						if containerFrame:IsEnabled() == true then
+							aParentChilds[tFriendlyName] = {
+								frameName = containerFrameName,
+								RoC = "Child",
+								type = "Button",
+								obj = containerFrame,
+								textFirstLine = tText,
+								textFull = "",
+								noMenuNumbers = true,
+								childs = {},
+							}   
+							--get the onclick func if there is one
+							if aParentChilds[tFriendlyName].obj:IsMouseClickEnabled() == true then
+								if aParentChilds[tFriendlyName].obj:GetObjectType() == "Button" then
+									aParentChilds[tFriendlyName].func = aParentChilds[tFriendlyName].obj:GetScript("OnClick")
+								end
+								aParentChilds[tFriendlyName].containerFrameName = containerFrameName
+								aParentChilds[tFriendlyName].onActionFunc = function(self, aTable, aChildName)
 
-                        end
-                        if aParentChilds[tFriendlyName].func then
-                           aParentChilds[tFriendlyName].click = true
-                        end
-                     end
+								end
+								if aParentChilds[tFriendlyName].func then
+									aParentChilds[tFriendlyName].click = true
+								end
+							end
 
 
 							local maybeText = getItemTooltipTextFromBagItem(aParentChilds[tFriendlyName].obj:GetParent():GetID(), aParentChilds[tFriendlyName].obj:GetID())
@@ -361,853 +361,853 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 								local itemId = aParentChilds[tFriendlyName].itemId
 								if itemId and IsEquippableItem(itemId) then
 									local comparisnSections = getItemComparisnSections(itemId, inventoryTooltipTextCache)
-                           if comparisnSections then
-                              for i, section in ipairs(comparisnSections) do
-                                 local sectionHeader = #comparisnSections > 1 and L["currently equipped"].." "..i.."\r\n" or L["currently equipped"].."\r\n"
-                                 table.insert(aParentChilds[tFriendlyName].textFull, i + 1, sectionHeader .. section)
-                              end
-                           end
+									if comparisnSections then
+										for i, section in ipairs(comparisnSections) do
+											local sectionHeader = #comparisnSections > 1 and L["currently equipped"].." "..i.."\r\n" or L["currently equipped"].."\r\n"
+											table.insert(aParentChilds[tFriendlyName].textFull, i + 1, sectionHeader .. section)
+										end
+									end
 								end
 							end
 
-                     if aParentChilds[tFriendlyName].textFirstLine == "" and aParentChilds[tFriendlyName].textFull == "" and aParentChilds[tFriendlyName].obj.ShowTooltip then
-                        GameTooltip:ClearLines()
-                        aParentChilds[tFriendlyName].obj:ShowTooltip()
-                        if TooltipLines_helper(GameTooltip:GetRegions()) ~= "asd" then
-                           if TooltipLines_helper(GameTooltip:GetRegions()) ~= "" then
-                              local tText = unescape(TooltipLines_helper(GameTooltip:GetRegions()))
-                              aParentChilds[tFriendlyName].textFirstLine, aParentChilds[tFriendlyName].textFull = ItemName_helper(tText)
-                           end
-                        end
-                     end
-                     
-                     
+							if aParentChilds[tFriendlyName].textFirstLine == "" and aParentChilds[tFriendlyName].textFull == "" and aParentChilds[tFriendlyName].obj.ShowTooltip then
+								GameTooltip:ClearLines()
+								aParentChilds[tFriendlyName].obj:ShowTooltip()
+								if TooltipLines_helper(GameTooltip:GetRegions()) ~= "asd" then
+									if TooltipLines_helper(GameTooltip:GetRegions()) ~= "" then
+										local tText = unescape(TooltipLines_helper(GameTooltip:GetRegions()))
+										aParentChilds[tFriendlyName].textFirstLine, aParentChilds[tFriendlyName].textFull = ItemName_helper(tText)
+									end
+								end
+							end
+							
+							
 
-                     if _G[containerFrameName .. "Count"] and not containerFrame.info then
-                        if aParentChilds[tFriendlyName] and _G[containerFrameName .. "Count"]:GetText() then
-                           if not string.find(aParentChilds[tFriendlyName].textFirstLine, L["Empty"].." ") then
-                              aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine .. " " .. _G[containerFrameName .. "Count"]:GetText()
-                           else
-                              aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine
-                           end
-                        end
-                     end
-                     if aParentChilds[tFriendlyName] and string.find(containerFrameName, "ContainerFrame") then
-                        if aParentChilds[tFriendlyName].textFirstLine then
-                           aParentChilds[tFriendlyName].textFirstLine = (#tBagResults[bagId].childs + 1).." "..aParentChilds[tFriendlyName].textFirstLine
-                           tEmptyCounter = tEmptyCounter + 1
-                        end
-                     end
-                     if _G[containerFrameName .. "Count"] and aParentChilds[tFriendlyName] then
-                        aParentChilds[tFriendlyName].stackSize = _G[containerFrameName .. "Count"]:GetText()
-                     end
-                     if containerFrame.info then
-                        aParentChilds[tFriendlyName].itemId = containerFrame.info.id
-                        if not containerFrame.info.count then
-                           aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine
-                        else
-                           if not string.find(aParentChilds[tFriendlyName].textFirstLine, L["Empty"] .. " ") and containerFrame.info.count > 1 then
-                              aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine .. " " .. containerFrame.info.count
-                           else
-                              aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine
-                           end
-                        end								
-                     end							
+							if _G[containerFrameName .. "Count"] and not containerFrame.info then
+								if aParentChilds[tFriendlyName] and _G[containerFrameName .. "Count"]:GetText() then
+									if not string.find(aParentChilds[tFriendlyName].textFirstLine, L["Empty"].." ") then
+										aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine .. " " .. _G[containerFrameName .. "Count"]:GetText()
+									else
+										aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine
+									end
+								end
+							end
+							if aParentChilds[tFriendlyName] and string.find(containerFrameName, "ContainerFrame") then
+								if aParentChilds[tFriendlyName].textFirstLine then
+									aParentChilds[tFriendlyName].textFirstLine = (#tBagResults[bagId].childs + 1).." "..aParentChilds[tFriendlyName].textFirstLine
+									tEmptyCounter = tEmptyCounter + 1
+								end
+							end
+							if _G[containerFrameName .. "Count"] and aParentChilds[tFriendlyName] then
+								aParentChilds[tFriendlyName].stackSize = _G[containerFrameName .. "Count"]:GetText()
+							end
+							if containerFrame.info then
+								aParentChilds[tFriendlyName].itemId = containerFrame.info.id
+								if not containerFrame.info.count then
+									aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine
+								else
+									if not string.find(aParentChilds[tFriendlyName].textFirstLine, L["Empty"] .. " ") and containerFrame.info.count > 1 then
+										aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine .. " " .. containerFrame.info.count
+									else
+										aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine
+									end
+								end								
+							end							
 
-                  end
-                  
-                  tBagResults[bagId].childs[#tBagResults[bagId].childs + 1] = aParentChilds[tFriendlyName]
+						end
+						
+						tBagResults[bagId].childs[#tBagResults[bagId].childs + 1] = aParentChilds[tFriendlyName]
 
-               end
-            end
-         end
-      end  
-   end
+					end
+				end
+			end
+		end  
+	end
 
-   for i, v in pairs(tBagResults) do
-      for ic, vc in pairs(v.childs) do
-         table.insert(v.obj.childs, vc)
-         v.obj.childs[vc] = vc
-      end
-   end
+	for i, v in pairs(tBagResults) do
+		for ic, vc in pairs(v.childs) do
+			table.insert(v.obj.childs, vc)
+			v.obj.childs[vc] = vc
+		end
+	end
 
 
-   local tFriendlyName = L["Bags"]
-   local tText, tFullText = L["Bags"], ""
-   table.insert(aParentChilds, tFriendlyName)
-   aParentChilds[tFriendlyName] = {
-      frameName = tFrameName,
-      RoC = "Child",
-      type = "Button",
-      obj = _G[tFrameName],
-      textFirstLine = tFriendlyName,
-      textFull = "",
-      noMenuNumbers = true,
-      childs = {},
-      func = nil,
-      click = true,
-   }   
+	local tFriendlyName = L["Bags"]
+	local tText, tFullText = L["Bags"], ""
+	table.insert(aParentChilds, tFriendlyName)
+	aParentChilds[tFriendlyName] = {
+		frameName = tFrameName,
+		RoC = "Child",
+		type = "Button",
+		obj = _G[tFrameName],
+		textFirstLine = tFriendlyName,
+		textFull = "",
+		noMenuNumbers = true,
+		childs = {},
+		func = nil,
+		click = true,
+	}   
 
-   tCurrentParentContainer = aParentChilds[tFriendlyName]
+	tCurrentParentContainer = aParentChilds[tFriendlyName]
 
-   local dtc = { BagnonInventoryFrame1.bagGroup:GetChildren() }
-   for x = 1, (#dtc - 1) do
-      if dtc[x] then
+	local dtc = { BagnonInventoryFrame1.bagGroup:GetChildren() }
+	for x = 1, (#dtc - 1) do
+		if dtc[x] then
 
-         local tFriendlyName = L["Bag-slot"].." "..(x + 1)
-         local tText, tFullText = L["Bag-slot"].." "..(x + 1), ""
-         if dtc[x]:IsEnabled() == true then
-            aParentChilds[tFriendlyName] = {
-               frameName = L["Bag-slot"]..(x + 1),
-               RoC = "Child",
-               type = "Button",
-               obj = dtc[x],
-               textFirstLine = tFriendlyName,
-               textFull = "",
-               noMenuNumbers = true,
-               childs = {},
-               func = dtc[x]:GetScript("OnClick"),
-               click = true,
-               isBag = true,
-            }   
-            if x == 1 or x == 6 then
-               aParentChilds[tFriendlyName].childs = {}
-               aParentChilds[tFriendlyName].type = "Text"
-               aParentChilds[tFriendlyName].func = nil
-            end   
+			local tFriendlyName = L["Bag-slot"].." "..(x + 1)
+			local tText, tFullText = L["Bag-slot"].." "..(x + 1), ""
+			if dtc[x]:IsEnabled() == true then
+				aParentChilds[tFriendlyName] = {
+					frameName = L["Bag-slot"]..(x + 1),
+					RoC = "Child",
+					type = "Button",
+					obj = dtc[x],
+					textFirstLine = tFriendlyName,
+					textFull = "",
+					noMenuNumbers = true,
+					childs = {},
+					func = dtc[x]:GetScript("OnClick"),
+					click = true,
+					isBag = true,
+				}   
+				if x == 1 or x == 6 then
+					aParentChilds[tFriendlyName].childs = {}
+					aParentChilds[tFriendlyName].type = "Text"
+					aParentChilds[tFriendlyName].func = nil
+				end   
 
-            GameTooltip:ClearLines()
-            aParentChilds[tFriendlyName].obj:GetScript("OnEnter")(aParentChilds[tFriendlyName].obj)
-            if TooltipLines_helper(GameTooltip:GetRegions()) ~= "asd" then
-               if TooltipLines_helper(GameTooltip:GetRegions()) ~= "" then
-                  local tText = unescape(TooltipLines_helper(GameTooltip:GetRegions()))
-                  if string.find(tText, "Equip Container") then
-                     tText = L["Empty"]
-                  end
-                  tText = x.." "..tText
-                  aParentChilds[tFriendlyName].textFirstLine, aParentChilds[tFriendlyName].textFull = ItemName_helper(tText)
-               end
-            end
-         end
-         
+				GameTooltip:ClearLines()
+				aParentChilds[tFriendlyName].obj:GetScript("OnEnter")(aParentChilds[tFriendlyName].obj)
+				if TooltipLines_helper(GameTooltip:GetRegions()) ~= "asd" then
+					if TooltipLines_helper(GameTooltip:GetRegions()) ~= "" then
+						local tText = unescape(TooltipLines_helper(GameTooltip:GetRegions()))
+						if string.find(tText, "Equip Container") then
+							tText = L["Empty"]
+						end
+						tText = x.." "..tText
+						aParentChilds[tFriendlyName].textFirstLine, aParentChilds[tFriendlyName].textFull = ItemName_helper(tText)
+					end
+				end
+			end
+			
 
-         table.insert(tCurrentParentContainer.childs, aParentChilds[tFriendlyName])
-         tCurrentParentContainer.childs[aParentChilds[tFriendlyName]] = aParentChilds[tFriendlyName]
-      end
-   end      
+			table.insert(tCurrentParentContainer.childs, aParentChilds[tFriendlyName])
+			tCurrentParentContainer.childs[aParentChilds[tFriendlyName]] = aParentChilds[tFriendlyName]
+		end
+	end      
 end
 
 ---------------------------------------------------------------------------------------------------------------------------------------
 local tTradeSkillTypeColor = {
-   [L["optimal"]] = { r = 1.00, g = 0.50, b = 0.25},
-   [L["medium"]] = { r = 1.00, g = 1.00, b = 0.00},
-   [L["easy"]] = { r = 0.25, g = 0.75, b = 0.25},
-   [L["trivial"]] = { r = 0.50, g = 0.50, b = 0.50},
-   ["header"] = { r = 1.00, g = 0.82, b = 0},
-   ["subheader"] = { r = 1.00, g = 0.82, b = 0},
-   [L["nodifficulty"]] = { r = 0.96, g = 0.96, b = 0.96},
+	[L["optimal"]] = { r = 1.00, g = 0.50, b = 0.25},
+	[L["medium"]] = { r = 1.00, g = 1.00, b = 0.00},
+	[L["easy"]] = { r = 0.25, g = 0.75, b = 0.25},
+	[L["trivial"]] = { r = 0.50, g = 0.50, b = 0.50},
+	["header"] = { r = 1.00, g = 0.82, b = 0},
+	["subheader"] = { r = 1.00, g = 0.82, b = 0},
+	[L["nodifficulty"]] = { r = 0.96, g = 0.96, b = 0.96},
 }
 local function round(num)
-   local mult = 10^(2 or 0)
-   return math.floor(num * mult + 0.5) / mult
+	local mult = 10^(2 or 0)
+	return math.floor(num * mult + 0.5) / mult
 end
 
 function SkuCore:Build_TradeSkillFrame(aParentChilds)
 
-   local tFrameName = "TradeSkillFrame"
-   local tFriendlyName = _G["TradeSkillFrameTitleText"]:GetText()
-   table.insert(aParentChilds, tFriendlyName)
-   aParentChilds[tFriendlyName] = {
-      frameName = tFrameName,
-      RoC = "Child",
-      type = "FontString",
-      obj = _G[tFrameName],
-      textFirstLine = tFriendlyName,
-      textFull = "",
-      childs = {},
-   }
+	local tFrameName = "TradeSkillFrame"
+	local tFriendlyName = _G["TradeSkillFrameTitleText"]:GetText()
+	table.insert(aParentChilds, tFriendlyName)
+	aParentChilds[tFriendlyName] = {
+		frameName = tFrameName,
+		RoC = "Child",
+		type = "FontString",
+		obj = _G[tFrameName],
+		textFirstLine = tFriendlyName,
+		textFull = "",
+		childs = {},
+	}
 
 
-   local tFrameName = "TradeSkillListScrollFrameScrollBarScrollUpButton"
-   if _G[tFrameName] then
-      if _G[tFrameName]:IsVisible() == true and _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-         local tFriendlyName = L["Hoch blättern"]
-         table.insert(aParentChilds, tFriendlyName)
-         aParentChilds[tFriendlyName] = {
-            frameName = tFrameName,
-            RoC = "Child",
-            type = "Button",
-            obj = _G[tFrameName],
-            textFirstLine = tFriendlyName,
-            textFull = "",
-            childs = {},
-            func = function(self, aButton)
-               self:GetScript("OnClick")(self, aButton)             
-               self:GetScript("OnClick")(self, aButton)             
-            end,            
-            click = true,
-         }   
-      end
-   end
+	local tFrameName = "TradeSkillListScrollFrameScrollBarScrollUpButton"
+	if _G[tFrameName] then
+		if _G[tFrameName]:IsVisible() == true and _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+			local tFriendlyName = L["Hoch blättern"]
+			table.insert(aParentChilds, tFriendlyName)
+			aParentChilds[tFriendlyName] = {
+				frameName = tFrameName,
+				RoC = "Child",
+				type = "Button",
+				obj = _G[tFrameName],
+				textFirstLine = tFriendlyName,
+				textFull = "",
+				childs = {},
+				func = function(self, aButton)
+					self:GetScript("OnClick")(self, aButton)             
+					self:GetScript("OnClick")(self, aButton)             
+				end,            
+				click = true,
+			}   
+		end
+	end
 
 
 
 
-   for x = 1, 8 do
-      local tFrameName = "TradeSkillSkill"..x
-      if _G[tFrameName] and _G[tFrameName].text and _G[tFrameName]:IsVisible() == true and _G[tFrameName]:IsEnabled() == true then
-         if _G[tFrameName].text:GetText() then
-            local tDifficulty = ""
-            local r, g, b, a = _G[tFrameName].text:GetTextColor()
-            r, g, b, a = round(r), round(g), round(b), round(a)
-            if r == 1 and g == 1 and  b == 1 then
-               if _G["TradeSkillHighlightFrame"] and _G["TradeSkillHighlightFrame"]:GetRegions() then
-                  r, g, b, a = _G["TradeSkillHighlightFrame"]:GetRegions():GetVertexColor()
-                  if r then
-                     r, g, b, a = round(r), round(g), round(b), round(a)
-                  end
-               end
-            end
+	for x = 1, 8 do
+		local tFrameName = "TradeSkillSkill"..x
+		if _G[tFrameName] and _G[tFrameName].text and _G[tFrameName]:IsVisible() == true and _G[tFrameName]:IsEnabled() == true then
+			if _G[tFrameName].text:GetText() then
+				local tDifficulty = ""
+				local r, g, b, a = _G[tFrameName].text:GetTextColor()
+				r, g, b, a = round(r), round(g), round(b), round(a)
+				if r == 1 and g == 1 and  b == 1 then
+					if _G["TradeSkillHighlightFrame"] and _G["TradeSkillHighlightFrame"]:GetRegions() then
+						r, g, b, a = _G["TradeSkillHighlightFrame"]:GetRegions():GetVertexColor()
+						if r then
+							r, g, b, a = round(r), round(g), round(b), round(a)
+						end
+					end
+				end
 
-            for i, v in pairs(tTradeSkillTypeColor) do
-               if v.r == r and v.g == g and  v.b == b then
-                  tDifficulty = i
-               end
-            end
+				for i, v in pairs(tTradeSkillTypeColor) do
+					if v.r == r and v.g == g and  v.b == b then
+						tDifficulty = i
+					end
+				end
 
-            local tFriendlyName = unescape(_G[tFrameName].text:GetText())
-            local tText, tFullText = "", ""
-            if _G[tFrameName]:IsEnabled() == true then
-               table.insert(aParentChilds, tFriendlyName)
-               aParentChilds[tFriendlyName] = {
-                  frameName = tFrameName,
-                  RoC = "Child",
-                  type = "Button",
-                  obj = _G[tFrameName],
-                  textFirstLine = tFriendlyName,
-                  textFull = "",
-                  childs = {},
-                  func = _G[tFrameName]:GetScript("OnClick"),
-                  click = true,
-               }   
-            end
+				local tFriendlyName = unescape(_G[tFrameName].text:GetText())
+				local tText, tFullText = "", ""
+				if _G[tFrameName]:IsEnabled() == true then
+					table.insert(aParentChilds, tFriendlyName)
+					aParentChilds[tFriendlyName] = {
+						frameName = tFrameName,
+						RoC = "Child",
+						type = "Button",
+						obj = _G[tFrameName],
+						textFirstLine = tFriendlyName,
+						textFull = "",
+						childs = {},
+						func = _G[tFrameName]:GetScript("OnClick"),
+						click = true,
+					}   
+				end
 
-            if tDifficulty == "subheader" or tDifficulty == "header" then
-               aParentChilds[tFriendlyName].click = false
-               aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine.." ("..L["category"]..")"
-            else
-               aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine.." ("..(tDifficulty or "")..")"
-            end
-         end
-      end
-   end
+				if tDifficulty == "subheader" or tDifficulty == "header" then
+					aParentChilds[tFriendlyName].click = false
+					aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine.." ("..L["category"]..")"
+				else
+					aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine.." ("..(tDifficulty or "")..")"
+				end
+			end
+		end
+	end
 
-   local tFrameName = "TradeSkillListScrollFrameScrollBarScrollDownButton"
-   if _G[tFrameName] then
-      if _G[tFrameName]:IsVisible() == true and _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-         local tFriendlyName = L["Runter blättern"]
-         table.insert(aParentChilds, tFriendlyName)
-         aParentChilds[tFriendlyName] = {
-            frameName = tFrameName,
-            RoC = "Child",
-            type = "Button",
-            obj = _G[tFrameName],
-            textFirstLine = tFriendlyName,
-            textFull = "",
-            childs = {},
-            func = function(self, aButton)
-               self:GetScript("OnClick")(self, aButton)             
-               self:GetScript("OnClick")(self, aButton)             
-            end,            
-            click = true,
-         }   
-      end
-   end
+	local tFrameName = "TradeSkillListScrollFrameScrollBarScrollDownButton"
+	if _G[tFrameName] then
+		if _G[tFrameName]:IsVisible() == true and _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+			local tFriendlyName = L["Runter blättern"]
+			table.insert(aParentChilds, tFriendlyName)
+			aParentChilds[tFriendlyName] = {
+				frameName = tFrameName,
+				RoC = "Child",
+				type = "Button",
+				obj = _G[tFrameName],
+				textFirstLine = tFriendlyName,
+				textFull = "",
+				childs = {},
+				func = function(self, aButton)
+					self:GetScript("OnClick")(self, aButton)             
+					self:GetScript("OnClick")(self, aButton)             
+				end,            
+				click = true,
+			}   
+		end
+	end
 
-   local tName = ""
-   if _G["TradeSkillSkillName"] then
-      tName = unescape(_G["TradeSkillSkillName"]:GetText()) or ""
-   end
-   local tRequirements = ""
-   if _G["TradeSkillRequirementText"] and _G["TradeSkillRequirementText"]:IsVisible() and _G["TradeSkillRequirementText"]:GetText() then
-      for i, v in string.gmatch(_G["TradeSkillRequirementText"]:GetText(), "([^,]+)") do 
-         if string.sub(i, 1, 1) == " " then
-            i = string.sub(i, 2)
-         end
-         local tReqStr = unescape(i) or ""
-         if string.find(i, "ff2020") then
-            tReqStr = tReqStr.." ("..L["missing"]..")"
-         end
-         tRequirements = tRequirements..tReqStr.."\r\n"
-      end
-   end
-   --[[
-   local tCost = ""
-   if _G["CraftCost"] and _G["CraftCost"]:GetText() then
-      tCost = unescape(_G["CraftCost"]:GetText()) or ""
-   end
-   local tDescription = ""
-   if _G["CraftDescription"] and _G["CraftDescription"]:GetText() then
-      tDescription = unescape(_G["CraftDescription"]:GetText()) or ""
-   end
-   ]]
+	local tName = ""
+	if _G["TradeSkillSkillName"] then
+		tName = unescape(_G["TradeSkillSkillName"]:GetText()) or ""
+	end
+	local tRequirements = ""
+	if _G["TradeSkillRequirementText"] and _G["TradeSkillRequirementText"]:IsVisible() and _G["TradeSkillRequirementText"]:GetText() then
+		for i, v in string.gmatch(_G["TradeSkillRequirementText"]:GetText(), "([^,]+)") do 
+			if string.sub(i, 1, 1) == " " then
+				i = string.sub(i, 2)
+			end
+			local tReqStr = unescape(i) or ""
+			if string.find(i, "ff2020") then
+				tReqStr = tReqStr.." ("..L["missing"]..")"
+			end
+			tRequirements = tRequirements..tReqStr.."\r\n"
+		end
+	end
+	--[[
+	local tCost = ""
+	if _G["CraftCost"] and _G["CraftCost"]:GetText() then
+		tCost = unescape(_G["CraftCost"]:GetText()) or ""
+	end
+	local tDescription = ""
+	if _G["CraftDescription"] and _G["CraftDescription"]:GetText() then
+		tDescription = unescape(_G["CraftDescription"]:GetText()) or ""
+	end
+	]]
 
-   local tReagents = ""
-   if _G["TradeSkillReagentLabel"] and _G["TradeSkillReagentLabel"]:IsVisible() == true then
-      tReagents = _G["TradeSkillReagentLabel"]:GetText()
-   end
-   for x = 1, 15 do
-      if _G["TradeSkillReagent"..x] then
-         if _G["TradeSkillReagent"..x]:IsVisible() == true then
-            tReagents = tReagents.."\r\n"..unescape(_G["TradeSkillReagent"..x.."Name"]:GetText())
-            tReagents = tReagents.." "..unescape(_G["TradeSkillReagent"..x.."Count"]:GetText())
-         end
-      end   
-   end
+	local tReagents = ""
+	if _G["TradeSkillReagentLabel"] and _G["TradeSkillReagentLabel"]:IsVisible() == true then
+		tReagents = _G["TradeSkillReagentLabel"]:GetText()
+	end
+	for x = 1, 15 do
+		if _G["TradeSkillReagent"..x] then
+			if _G["TradeSkillReagent"..x]:IsVisible() == true then
+				tReagents = tReagents.."\r\n"..unescape(_G["TradeSkillReagent"..x.."Name"]:GetText())
+				tReagents = tReagents.." "..unescape(_G["TradeSkillReagent"..x.."Count"]:GetText())
+			end
+		end   
+	end
 
-   local tFrameName = "TradeSkillDetailScrollChildFrame"
-   if tName and tName ~= "" then
-      local tFriendlyName = L["Ausgewählt: "]..tName
-      table.insert(aParentChilds, tFriendlyName)
-      aParentChilds[tFriendlyName] = {
-         frameName = tFrameName,
-         RoC = "Child",
-         type = "FontString",
-         obj = _G[tFrameName],
-         textFirstLine = tFriendlyName,
-         textFull = tName..(("\r\n"..tRequirements) or "")..(("\r\n"..tReagents) or ""),
-         childs = {},
-      }   
-   end
+	local tFrameName = "TradeSkillDetailScrollChildFrame"
+	if tName and tName ~= "" then
+		local tFriendlyName = L["Ausgewählt: "]..tName
+		table.insert(aParentChilds, tFriendlyName)
+		aParentChilds[tFriendlyName] = {
+			frameName = tFrameName,
+			RoC = "Child",
+			type = "FontString",
+			obj = _G[tFrameName],
+			textFirstLine = tFriendlyName,
+			textFull = tName..(("\r\n"..tRequirements) or "")..(("\r\n"..tReagents) or ""),
+			childs = {},
+		}   
+	end
 
-   local tFrameName = "TradeSkillCreateButton"
-   if _G[tFrameName] then
-      if _G[tFrameName]:IsVisible() == true and _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-         if _G[tFrameName]:GetText() then
-            local tFriendlyName = unescape(_G[tFrameName]:GetText())
-            table.insert(aParentChilds, tFriendlyName)
-            aParentChilds[tFriendlyName] = {
-               frameName = tFrameName,
-               RoC = "Child",
-               type = "Button",
-               obj = _G[tFrameName],
-               textFirstLine = tFriendlyName,
-               textFull = "",
-               childs = {},
-               func = _G[tFrameName]:GetScript("OnClick"),
-               click = true,
-               containerFrameName = "TradeSkillCreateButton",
-               onActionFunc = function(self, aTable, aChildName) end,
-            }   
-         end
-      end
-   end
-   local tFrameName = "TradeSkillCreateAllButton"
-   if _G[tFrameName] then
-      if _G[tFrameName]:IsVisible() == true and _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-         if _G[tFrameName]:GetText() then
-            local tFriendlyName = unescape(_G[tFrameName]:GetText())
-            table.insert(aParentChilds, tFriendlyName)
-            aParentChilds[tFriendlyName] = {
-               frameName = tFrameName,
-               RoC = "Child",
-               type = "Button",
-               obj = _G[tFrameName],
-               textFirstLine = tFriendlyName,
-               textFull = "",
-               childs = {},
-               func = _G[tFrameName]:GetScript("OnClick"),
-               click = true,
-               containerFrameName = "TradeSkillCreateAllButton",
-               onActionFunc = function(self, aTable, aChildName) end,
-            }   
-         end
-      end
-   end
+	local tFrameName = "TradeSkillCreateButton"
+	if _G[tFrameName] then
+		if _G[tFrameName]:IsVisible() == true and _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+			if _G[tFrameName]:GetText() then
+				local tFriendlyName = unescape(_G[tFrameName]:GetText())
+				table.insert(aParentChilds, tFriendlyName)
+				aParentChilds[tFriendlyName] = {
+					frameName = tFrameName,
+					RoC = "Child",
+					type = "Button",
+					obj = _G[tFrameName],
+					textFirstLine = tFriendlyName,
+					textFull = "",
+					childs = {},
+					func = _G[tFrameName]:GetScript("OnClick"),
+					click = true,
+					containerFrameName = "TradeSkillCreateButton",
+					onActionFunc = function(self, aTable, aChildName) end,
+				}   
+			end
+		end
+	end
+	local tFrameName = "TradeSkillCreateAllButton"
+	if _G[tFrameName] then
+		if _G[tFrameName]:IsVisible() == true and _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+			if _G[tFrameName]:GetText() then
+				local tFriendlyName = unescape(_G[tFrameName]:GetText())
+				table.insert(aParentChilds, tFriendlyName)
+				aParentChilds[tFriendlyName] = {
+					frameName = tFrameName,
+					RoC = "Child",
+					type = "Button",
+					obj = _G[tFrameName],
+					textFirstLine = tFriendlyName,
+					textFull = "",
+					childs = {},
+					func = _G[tFrameName]:GetScript("OnClick"),
+					click = true,
+					containerFrameName = "TradeSkillCreateAllButton",
+					onActionFunc = function(self, aTable, aChildName) end,
+				}   
+			end
+		end
+	end
 
 
-   local tFrameName = "TradeSkillFrameCloseButton"
-   local tFriendlyName = L["Schließen"]
-   if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-      table.insert(aParentChilds, tFriendlyName)
-      aParentChilds[tFriendlyName] = {
-         frameName = tFrameName,
-         RoC = "Child",
-         type = "Button",
-         obj = _G[tFrameName],
-         textFirstLine = tFriendlyName,
-         textFull = "",
-         childs = {},
-         func = _G[tFrameName]:GetScript("OnClick"),
-         click = true,
-      }   
-   end   
+	local tFrameName = "TradeSkillFrameCloseButton"
+	local tFriendlyName = L["Schließen"]
+	if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+		table.insert(aParentChilds, tFriendlyName)
+		aParentChilds[tFriendlyName] = {
+			frameName = tFrameName,
+			RoC = "Child",
+			type = "Button",
+			obj = _G[tFrameName],
+			textFirstLine = tFriendlyName,
+			textFull = "",
+			childs = {},
+			func = _G[tFrameName]:GetScript("OnClick"),
+			click = true,
+		}   
+	end   
 
 end
 
 ---------------------------------------------------------------------------------------------------------------------------------------
 function SkuCore:Build_CraftFrame(aParentChilds)
 
-   local tFrameName = "CraftFrame"
-   local tFriendlyName = _G["CraftFrameTitleText"]:GetText()
-   table.insert(aParentChilds, tFriendlyName)
-   aParentChilds[tFriendlyName] = {
-      frameName = tFrameName,
-      RoC = "Child",
-      type = "FontString",
-      obj = _G[tFrameName],
-      textFirstLine = tFriendlyName,
-      textFull = "",
-      childs = {},
-   }
+	local tFrameName = "CraftFrame"
+	local tFriendlyName = _G["CraftFrameTitleText"]:GetText()
+	table.insert(aParentChilds, tFriendlyName)
+	aParentChilds[tFriendlyName] = {
+		frameName = tFrameName,
+		RoC = "Child",
+		type = "FontString",
+		obj = _G[tFrameName],
+		textFirstLine = tFriendlyName,
+		textFull = "",
+		childs = {},
+	}
 
-   if _G["CraftFramePointsText"] and _G["CraftFramePointsText"]:IsVisible() == true then
-      local tFrameName = "CraftFramePointsText"
-      local tFriendlyName = L["Verfügbare punkte: "]
-      tFriendlyName = tFriendlyName..(_G["CraftFramePointsText"]:GetText() or "")
-      table.insert(aParentChilds, tFriendlyName)
-      aParentChilds[tFriendlyName] = {
-         frameName = tFrameName,
-         RoC = "Child",
-         type = "FontString",
-         obj = _G[tFrameName],
-         textFirstLine = tFriendlyName,
-         textFull = "",
-         childs = {},
-      }  
-   end
+	if _G["CraftFramePointsText"] and _G["CraftFramePointsText"]:IsVisible() == true then
+		local tFrameName = "CraftFramePointsText"
+		local tFriendlyName = L["Verfügbare punkte: "]
+		tFriendlyName = tFriendlyName..(_G["CraftFramePointsText"]:GetText() or "")
+		table.insert(aParentChilds, tFriendlyName)
+		aParentChilds[tFriendlyName] = {
+			frameName = tFrameName,
+			RoC = "Child",
+			type = "FontString",
+			obj = _G[tFrameName],
+			textFirstLine = tFriendlyName,
+			textFull = "",
+			childs = {},
+		}  
+	end
 
-   local tFrameName = "CraftListScrollFrameScrollBarScrollUpButton"
-   if _G[tFrameName] then
-      if _G[tFrameName]:IsVisible() == true and _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-         local tFriendlyName = L["Hoch blättern"]
-         table.insert(aParentChilds, tFriendlyName)
-         aParentChilds[tFriendlyName] = {
-            frameName = tFrameName,
-            RoC = "Child",
-            type = "Button",
-            obj = _G[tFrameName],
-            textFirstLine = tFriendlyName,
-            textFull = "",
-            childs = {},
-            func = function(self, aButton)
-               self:GetScript("OnClick")(self, aButton)             
-               self:GetScript("OnClick")(self, aButton)             
-            end,            
-            click = true,
-         }   
-      end
-   end
+	local tFrameName = "CraftListScrollFrameScrollBarScrollUpButton"
+	if _G[tFrameName] then
+		if _G[tFrameName]:IsVisible() == true and _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+			local tFriendlyName = L["Hoch blättern"]
+			table.insert(aParentChilds, tFriendlyName)
+			aParentChilds[tFriendlyName] = {
+				frameName = tFrameName,
+				RoC = "Child",
+				type = "Button",
+				obj = _G[tFrameName],
+				textFirstLine = tFriendlyName,
+				textFull = "",
+				childs = {},
+				func = function(self, aButton)
+					self:GetScript("OnClick")(self, aButton)             
+					self:GetScript("OnClick")(self, aButton)             
+				end,            
+				click = true,
+			}   
+		end
+	end
 
-   for x = 1, 8 do
-      local tFrameName = "Craft"..x
-      if _G[tFrameName] then
-         if _G[tFrameName.."Text"]:GetText() then
-            local tKnown = ""
-            local tDifficulty = ""
-            local r, g, b, a = _G[tFrameName].text:GetTextColor()
-            r, g, b, a = round(r), round(g), round(b), round(a)
-            if r == 1 and g == 1 and  b == 1 then
-               if _G["CraftHighlightFrame"] and _G["CraftHighlightFrame"]:GetRegions() then
-                  r, g, b, a = _G["CraftHighlightFrame"]:GetRegions():GetVertexColor()
-                  if r then
-                     r, g, b, a = round(r), round(g), round(b), round(a)
-                  end
-               end
-            end
+	for x = 1, 8 do
+		local tFrameName = "Craft"..x
+		if _G[tFrameName] then
+			if _G[tFrameName.."Text"]:GetText() then
+				local tKnown = ""
+				local tDifficulty = ""
+				local r, g, b, a = _G[tFrameName].text:GetTextColor()
+				r, g, b, a = round(r), round(g), round(b), round(a)
+				if r == 1 and g == 1 and  b == 1 then
+					if _G["CraftHighlightFrame"] and _G["CraftHighlightFrame"]:GetRegions() then
+						r, g, b, a = _G["CraftHighlightFrame"]:GetRegions():GetVertexColor()
+						if r then
+							r, g, b, a = round(r), round(g), round(b), round(a)
+						end
+					end
+				end
 
-            for i, v in pairs(tTradeSkillTypeColor) do
-               if v.r == r and v.g == g and  v.b == b then
-                  tDifficulty = i
-               end
-            end
+				for i, v in pairs(tTradeSkillTypeColor) do
+					if v.r == r and v.g == g and  v.b == b then
+						tDifficulty = i
+					end
+				end
 
-            local tFriendlyName = unescape(_G[tFrameName.."Text"]:GetText()).." ".. (unescape(_G[tFrameName.."SubText"]:GetText()) or "").." ".. (unescape(_G[tFrameName.."Cost"]:GetText()) or "").." "..tKnown
-            local tText, tFullText = "", ""
-            if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-               table.insert(aParentChilds, tFriendlyName)
-               aParentChilds[tFriendlyName] = {
-                  frameName = tFrameName,
-                  RoC = "Child",
-                  type = "Button",
-                  obj = _G[tFrameName],
-                  textFirstLine = tFriendlyName,
-                  textFull = "",
-                  childs = {},
-                  func = _G[tFrameName]:GetScript("OnClick"),
-                  click = true,
-               }   
-            end
+				local tFriendlyName = unescape(_G[tFrameName.."Text"]:GetText()).." ".. (unescape(_G[tFrameName.."SubText"]:GetText()) or "").." ".. (unescape(_G[tFrameName.."Cost"]:GetText()) or "").." "..tKnown
+				local tText, tFullText = "", ""
+				if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+					table.insert(aParentChilds, tFriendlyName)
+					aParentChilds[tFriendlyName] = {
+						frameName = tFrameName,
+						RoC = "Child",
+						type = "Button",
+						obj = _G[tFrameName],
+						textFirstLine = tFriendlyName,
+						textFull = "",
+						childs = {},
+						func = _G[tFrameName]:GetScript("OnClick"),
+						click = true,
+					}   
+				end
 
-            if tDifficulty == "subheader" or tDifficulty == "header" then
-               aParentChilds[tFriendlyName].click = false
-               aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine.." ("..L["category"]..")"
-            else
-               aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine.." ("..(tDifficulty or "")..")"
-            end            
-         end
-      end
-   end
+				if tDifficulty == "subheader" or tDifficulty == "header" then
+					aParentChilds[tFriendlyName].click = false
+					aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine.." ("..L["category"]..")"
+				else
+					aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine.." ("..(tDifficulty or "")..")"
+				end            
+			end
+		end
+	end
 
-   local tFrameName = "CraftListScrollFrameScrollBarScrollDownButton"
-   if _G[tFrameName] then
-      if _G[tFrameName]:IsVisible() == true and _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-         local tFriendlyName = L["Runter blättern"]
-         table.insert(aParentChilds, tFriendlyName)
-         aParentChilds[tFriendlyName] = {
-            frameName = tFrameName,
-            RoC = "Child",
-            type = "Button",
-            obj = _G[tFrameName],
-            textFirstLine = tFriendlyName,
-            textFull = "",
-            childs = {},
-            func = function(self, aButton)
-               self:GetScript("OnClick")(self, aButton)             
-               self:GetScript("OnClick")(self, aButton)             
-            end,            
-            click = true,
-         }   
-      end
-   end
+	local tFrameName = "CraftListScrollFrameScrollBarScrollDownButton"
+	if _G[tFrameName] then
+		if _G[tFrameName]:IsVisible() == true and _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+			local tFriendlyName = L["Runter blättern"]
+			table.insert(aParentChilds, tFriendlyName)
+			aParentChilds[tFriendlyName] = {
+				frameName = tFrameName,
+				RoC = "Child",
+				type = "Button",
+				obj = _G[tFrameName],
+				textFirstLine = tFriendlyName,
+				textFull = "",
+				childs = {},
+				func = function(self, aButton)
+					self:GetScript("OnClick")(self, aButton)             
+					self:GetScript("OnClick")(self, aButton)             
+				end,            
+				click = true,
+			}   
+		end
+	end
 
-   local tName = ""
-   if _G["CraftName"] then
-      tName = unescape(_G["CraftName"]:GetText()) or ""
-   end
-   local tRequirements = ""
-   if _G["CraftRequirements"] and _G["CraftRequirements"]:IsVisible() and _G["CraftRequirements"]:GetText() then
-      tRequirements = unescape(_G["CraftRequirements"]:GetText()) or ""
-      if string.find(_G["CraftRequirements"]:GetText(), "ff2020") then
-         tRequirements = tRequirements.." ("..L["missing"]..")"
-      end
-   end
-   local tCost = ""
-   if _G["CraftCost"] and _G["CraftCost"]:GetText() then
-      tCost = unescape(_G["CraftCost"]:GetText()) or ""
-   end
-   local tDescription = ""
-   if _G["CraftDescription"] and _G["CraftDescription"]:GetText() then
-      tDescription = unescape(_G["CraftDescription"]:GetText()) or ""
-   end
+	local tName = ""
+	if _G["CraftName"] then
+		tName = unescape(_G["CraftName"]:GetText()) or ""
+	end
+	local tRequirements = ""
+	if _G["CraftRequirements"] and _G["CraftRequirements"]:IsVisible() and _G["CraftRequirements"]:GetText() then
+		tRequirements = unescape(_G["CraftRequirements"]:GetText()) or ""
+		if string.find(_G["CraftRequirements"]:GetText(), "ff2020") then
+			tRequirements = tRequirements.." ("..L["missing"]..")"
+		end
+	end
+	local tCost = ""
+	if _G["CraftCost"] and _G["CraftCost"]:GetText() then
+		tCost = unescape(_G["CraftCost"]:GetText()) or ""
+	end
+	local tDescription = ""
+	if _G["CraftDescription"] and _G["CraftDescription"]:GetText() then
+		tDescription = unescape(_G["CraftDescription"]:GetText()) or ""
+	end
 
-   local tReagents = ""
-   if _G["CraftReagentLabel"] and _G["CraftReagentLabel"]:IsVisible() == true then
-      tReagents = _G["CraftReagentLabel"]:GetText()
-   end
-   for x = 1, 15 do
-      if _G["CraftReagent"..x] then
-         if _G["CraftReagent"..x]:IsVisible() == true then
-            tReagents = tReagents.."\r\n"..unescape(_G["CraftReagent"..x.."Name"]:GetText())
-            tReagents = tReagents.." "..unescape(_G["CraftReagent"..x.."Count"]:GetText())
-         end
-      end   
-   end
+	local tReagents = ""
+	if _G["CraftReagentLabel"] and _G["CraftReagentLabel"]:IsVisible() == true then
+		tReagents = _G["CraftReagentLabel"]:GetText()
+	end
+	for x = 1, 15 do
+		if _G["CraftReagent"..x] then
+			if _G["CraftReagent"..x]:IsVisible() == true then
+				tReagents = tReagents.."\r\n"..unescape(_G["CraftReagent"..x.."Name"]:GetText())
+				tReagents = tReagents.." "..unescape(_G["CraftReagent"..x.."Count"]:GetText())
+			end
+		end   
+	end
 
-   local tFrameName = "CraftDetailScrollChildFrame"
-   if tName and tName ~= "" then
-      local tFriendlyName = L["Ausgewählt: "]..tName
-      table.insert(aParentChilds, tFriendlyName)
-      aParentChilds[tFriendlyName] = {
-         frameName = tFrameName,
-         RoC = "Child",
-         type = "FontString",
-         obj = _G[tFrameName],
-         textFirstLine = tFriendlyName,
-         textFull = tName..(("\r\n"..tRequirements) or "")..(("\r\n"..tCost) or "")..(("\r\n"..tDescription) or "")..(("\r\n"..tReagents) or ""),
-         childs = {},
-      }   
-   end
+	local tFrameName = "CraftDetailScrollChildFrame"
+	if tName and tName ~= "" then
+		local tFriendlyName = L["Ausgewählt: "]..tName
+		table.insert(aParentChilds, tFriendlyName)
+		aParentChilds[tFriendlyName] = {
+			frameName = tFrameName,
+			RoC = "Child",
+			type = "FontString",
+			obj = _G[tFrameName],
+			textFirstLine = tFriendlyName,
+			textFull = tName..(("\r\n"..tRequirements) or "")..(("\r\n"..tCost) or "")..(("\r\n"..tDescription) or "")..(("\r\n"..tReagents) or ""),
+			childs = {},
+		}   
+	end
 
-   local tFrameName = "CraftCreateButton"
-   if _G[tFrameName] then
-      if _G[tFrameName]:IsVisible() == true and _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-         if _G[tFrameName]:GetText() then
-            local tFriendlyName = unescape(_G[tFrameName]:GetText())
-            table.insert(aParentChilds, tFriendlyName)
-            aParentChilds[tFriendlyName] = {
-               frameName = tFrameName,
-               RoC = "Child",
-               type = "Button",
-               obj = _G[tFrameName],
-               textFirstLine = tFriendlyName,
-               textFull = "",
-               childs = {},
-               func = _G[tFrameName]:GetScript("OnClick"),
-               click = true,
-               containerFrameName = "CraftCreateButton",
-               onActionFunc = function(self, aTable, aChildName) end,
-            }   
-         end
-      end
-   end
+	local tFrameName = "CraftCreateButton"
+	if _G[tFrameName] then
+		if _G[tFrameName]:IsVisible() == true and _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+			if _G[tFrameName]:GetText() then
+				local tFriendlyName = unescape(_G[tFrameName]:GetText())
+				table.insert(aParentChilds, tFriendlyName)
+				aParentChilds[tFriendlyName] = {
+					frameName = tFrameName,
+					RoC = "Child",
+					type = "Button",
+					obj = _G[tFrameName],
+					textFirstLine = tFriendlyName,
+					textFull = "",
+					childs = {},
+					func = _G[tFrameName]:GetScript("OnClick"),
+					click = true,
+					containerFrameName = "CraftCreateButton",
+					onActionFunc = function(self, aTable, aChildName) end,
+				}   
+			end
+		end
+	end
 
-   local tFrameName = "CraftFrameCloseButton"
-   local tFriendlyName = L["Schließen"]
-   if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-      table.insert(aParentChilds, tFriendlyName)
-      aParentChilds[tFriendlyName] = {
-         frameName = tFrameName,
-         RoC = "Child",
-         type = "Button",
-         obj = _G[tFrameName],
-         textFirstLine = tFriendlyName,
-         textFull = "",
-         childs = {},
-         func = _G[tFrameName]:GetScript("OnClick"),
-         click = true,
-      }   
-   end
+	local tFrameName = "CraftFrameCloseButton"
+	local tFriendlyName = L["Schließen"]
+	if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+		table.insert(aParentChilds, tFriendlyName)
+		aParentChilds[tFriendlyName] = {
+			frameName = tFrameName,
+			RoC = "Child",
+			type = "Button",
+			obj = _G[tFrameName],
+			textFirstLine = tFriendlyName,
+			textFull = "",
+			childs = {},
+			func = _G[tFrameName]:GetScript("OnClick"),
+			click = true,
+		}   
+	end
 end
 
 ---------------------------------------------------------------------------------------------------------------------------------------
 function SkuCore:Build_PetStableFrame(aParentChilds)
 
-   local tFrame = _G["PetStableCurrentPet"]
-   local tText, tFullText = GetButtonTooltipLines(tFrame)
-   table.insert(aParentChilds, L["Derzeitiger Begleiter"])
-   aParentChilds[L["Derzeitiger Begleiter"]] = {
-      frameName = "PetStableCurrentPet",
-      RoC = "Child",
-      type = "Button",
-      obj = tFrame,
-      textFirstLine = L["Derzeitiger Begleiter"].." "..tText,
-      textFull = L["Derzeitiger Begleiter"].." "..tFullText,
-      childs = {},
-      func = function(...)
-         local tCursorInfo = GetCursorInfo() 
-         if tCursorInfo then
-            tFrame:GetScript("OnReceiveDrag")(...)
-         else
-            tFrame:GetScript("OnDragStart")(...)
-         end
-      end,
-      click = true,
-   }   
+	local tFrame = _G["PetStableCurrentPet"]
+	local tText, tFullText = GetButtonTooltipLines(tFrame)
+	table.insert(aParentChilds, L["Derzeitiger Begleiter"])
+	aParentChilds[L["Derzeitiger Begleiter"]] = {
+		frameName = "PetStableCurrentPet",
+		RoC = "Child",
+		type = "Button",
+		obj = tFrame,
+		textFirstLine = L["Derzeitiger Begleiter"].." "..tText,
+		textFull = L["Derzeitiger Begleiter"].." "..tFullText,
+		childs = {},
+		func = function(...)
+			local tCursorInfo = GetCursorInfo() 
+			if tCursorInfo then
+				tFrame:GetScript("OnReceiveDrag")(...)
+			else
+				tFrame:GetScript("OnDragStart")(...)
+			end
+		end,
+		click = true,
+	}   
 
-   local tFrame = _G["PetStableStabledPet1"]
-   if tFrame:IsEnabled() == true then --IsMouseClickEnabled()
-      local tText, tFullText = GetButtonTooltipLines(tFrame)
-      table.insert(aParentChilds, L["Stall 1"])
-      aParentChilds[L["Stall 1"]] = {
-         frameName = "PetStableStabledPet1",
-         RoC = "Child",
-         type = "Button",
-         obj = tFrame,
-         textFirstLine = L["Stall 1"].." "..tText,
-         textFull = L["Stall 1"].." "..tFullText,
-         childs = {},
-         func = function(...)
-            local tCursorInfo = GetCursorInfo() 
-            if tCursorInfo then
-               tFrame:GetScript("OnReceiveDrag")(...)
-            else
-               tFrame:GetScript("OnDragStart")(...)
-            end
-         end,
-         click = true,
-      }
-   end
+	local tFrame = _G["PetStableStabledPet1"]
+	if tFrame:IsEnabled() == true then --IsMouseClickEnabled()
+		local tText, tFullText = GetButtonTooltipLines(tFrame)
+		table.insert(aParentChilds, L["Stall 1"])
+		aParentChilds[L["Stall 1"]] = {
+			frameName = "PetStableStabledPet1",
+			RoC = "Child",
+			type = "Button",
+			obj = tFrame,
+			textFirstLine = L["Stall 1"].." "..tText,
+			textFull = L["Stall 1"].." "..tFullText,
+			childs = {},
+			func = function(...)
+				local tCursorInfo = GetCursorInfo() 
+				if tCursorInfo then
+					tFrame:GetScript("OnReceiveDrag")(...)
+				else
+					tFrame:GetScript("OnDragStart")(...)
+				end
+			end,
+			click = true,
+		}
+	end
 
-   local tFrame = _G["PetStableStabledPet2"]
-   if tFrame:IsEnabled() == true then --IsMouseClickEnabled()
-      local tText, tFullText = GetButtonTooltipLines(tFrame)
-      table.insert(aParentChilds, L["Stall 2"])
-      aParentChilds[L["Stall 2"]] = {
-         frameName = "PetStableStabledPet2",
-         RoC = "Child",
-         type = "Button",
-         obj = tFrame,
-         textFirstLine = L["Stall 2"].." "..tText,
-         textFull = L["Stall 2"].." "..tFullText,
-         childs = {},
-         func = function(...)
-            local tCursorInfo = GetCursorInfo() 
-            if tCursorInfo then
-               tFrame:GetScript("OnReceiveDrag")(...)
-            else
-               tFrame:GetScript("OnDragStart")(...)
-            end
-         end,
-         click = true,
-      }
-   end
+	local tFrame = _G["PetStableStabledPet2"]
+	if tFrame:IsEnabled() == true then --IsMouseClickEnabled()
+		local tText, tFullText = GetButtonTooltipLines(tFrame)
+		table.insert(aParentChilds, L["Stall 2"])
+		aParentChilds[L["Stall 2"]] = {
+			frameName = "PetStableStabledPet2",
+			RoC = "Child",
+			type = "Button",
+			obj = tFrame,
+			textFirstLine = L["Stall 2"].." "..tText,
+			textFull = L["Stall 2"].." "..tFullText,
+			childs = {},
+			func = function(...)
+				local tCursorInfo = GetCursorInfo() 
+				if tCursorInfo then
+					tFrame:GetScript("OnReceiveDrag")(...)
+				else
+					tFrame:GetScript("OnDragStart")(...)
+				end
+			end,
+			click = true,
+		}
+	end
 
-   local tFrame = _G["PetStablePurchaseButton"]
-   if tFrame:IsEnabled() == true then --IsMouseClickEnabled()
-      if tFrame:IsShown() == true then --IsMouseClickEnabled()
-         table.insert(aParentChilds, L["Weiteren Platz kaufen"])
-         aParentChilds[L["Weiteren Platz kaufen"]] = {
-            frameName = "PetStablePurchaseButton",
-            RoC = "Child",
-            type = "Button",
-            obj = tFrame,
-            textFirstLine = L["Weiteren Platz kaufen"],
-            textFull = "",
-            childs = {},
-            func = tFrame:GetScript("OnClick"),
-            click = true,
-         }   
-      end
-   end
+	local tFrame = _G["PetStablePurchaseButton"]
+	if tFrame:IsEnabled() == true then --IsMouseClickEnabled()
+		if tFrame:IsShown() == true then --IsMouseClickEnabled()
+			table.insert(aParentChilds, L["Weiteren Platz kaufen"])
+			aParentChilds[L["Weiteren Platz kaufen"]] = {
+				frameName = "PetStablePurchaseButton",
+				RoC = "Child",
+				type = "Button",
+				obj = tFrame,
+				textFirstLine = L["Weiteren Platz kaufen"],
+				textFull = "",
+				childs = {},
+				func = tFrame:GetScript("OnClick"),
+				click = true,
+			}   
+		end
+	end
 
-   local tFrame = _G["PetStableFrameCloseButton"]
-   if tFrame:IsEnabled() == true then --IsMouseClickEnabled()
-      table.insert(aParentChilds, L["Schließen"])
-      aParentChilds[L["Schließen"]] = {
-         frameName = "PetStableFrameCloseButton",
-         RoC = "Child",
-         type = "Button",
-         obj = tFrame,
-         textFirstLine = L["Schließen"],
-         textFull = "",
-         childs = {},
-         func = tFrame:GetScript("OnClick"),
-         click = true,
-      }   
-   end
+	local tFrame = _G["PetStableFrameCloseButton"]
+	if tFrame:IsEnabled() == true then --IsMouseClickEnabled()
+		table.insert(aParentChilds, L["Schließen"])
+		aParentChilds[L["Schließen"]] = {
+			frameName = "PetStableFrameCloseButton",
+			RoC = "Child",
+			type = "Button",
+			obj = tFrame,
+			textFirstLine = L["Schließen"],
+			textFull = "",
+			childs = {},
+			func = tFrame:GetScript("OnClick"),
+			click = true,
+		}   
+	end
 end
 
 -----------------------------------------------------------------------------------------------------------------------------------------------------
 function SkuCore:ItemTextFrame(aParent)
-   local tFrameName = "ItemTextTitleText"
-   if _G[tFrameName]:IsShown() == true  then
-      local tText = _G[tFrameName]:GetText()
-      local tFrst, tFll = ItemName_helper(tText)
-      local tFriendlyName = tFrst
-      table.insert(aParent, tFriendlyName)
-      aParent[tFriendlyName] = {
-         frameName = tFrameName,
-         RoC = "Child",
-         type = "FontString",
-         obj = _G[tFrameName],
-         textFirstLine = tFrst,
-         textFull = tFll,
-         childs = {},
-      }
-   end
+	local tFrameName = "ItemTextTitleText"
+	if _G[tFrameName]:IsShown() == true  then
+		local tText = _G[tFrameName]:GetText()
+		local tFrst, tFll = ItemName_helper(tText)
+		local tFriendlyName = tFrst
+		table.insert(aParent, tFriendlyName)
+		aParent[tFriendlyName] = {
+			frameName = tFrameName,
+			RoC = "Child",
+			type = "FontString",
+			obj = _G[tFrameName],
+			textFirstLine = tFrst,
+			textFull = tFll,
+			childs = {},
+		}
+	end
 
-   local tFrameName = "ItemTextPageText"
-   if _G[tFrameName]:IsShown() == true  then
-      local tHtmlTable = _G[tFrameName]:GetTextData()
+	local tFrameName = "ItemTextPageText"
+	if _G[tFrameName]:IsShown() == true  then
+		local tHtmlTable = _G[tFrameName]:GetTextData()
 
-      local tText = ""
-      for i, v in pairs(tHtmlTable) do
-         if v.text then
-            tText = unescape(v.text).."\r\n"
-         end
-      end
+		local tText = ""
+		for i, v in pairs(tHtmlTable) do
+			if v.text then
+				tText = unescape(v.text).."\r\n"
+			end
+		end
 
-      local tFrst, tFll = ItemName_helper(tText)
-      local tFriendlyName = tFrst
-      table.insert(aParent, tFriendlyName)
-      aParent[tFriendlyName] = {
-         frameName = tFrameName,
-         RoC = "Child",
-         type = "FontString",
-         obj = _G[tFrameName],
-         textFirstLine = tFrst,
-         textFull = tFll,
-         childs = {},
-      }
-   end
+		local tFrst, tFll = ItemName_helper(tText)
+		local tFriendlyName = tFrst
+		table.insert(aParent, tFriendlyName)
+		aParent[tFriendlyName] = {
+			frameName = tFrameName,
+			RoC = "Child",
+			type = "FontString",
+			obj = _G[tFrameName],
+			textFirstLine = tFrst,
+			textFull = tFll,
+			childs = {},
+		}
+	end
 
-   local tFrameName = "ItemTextPrevPageButton"
-   if _G[tFrameName]:IsShown() == true  then
-      local tFriendlyName = L["Previous"]
-      local tFrst, tFll = tFriendlyName, ""
-      table.insert(aParent, tFriendlyName)
-      aParent[tFriendlyName] = {
-         frameName = tFrameName,
-         RoC = "Child",
-         type = "Button",
-         obj = _G[tFrameName],
-         textFirstLine = tFrst,
-         textFull = tFll,
-         childs = {},
-         func = _G[tFrameName]:GetScript("OnClick"),
-         click = true,
-      }
-   end
+	local tFrameName = "ItemTextPrevPageButton"
+	if _G[tFrameName]:IsShown() == true  then
+		local tFriendlyName = L["Previous"]
+		local tFrst, tFll = tFriendlyName, ""
+		table.insert(aParent, tFriendlyName)
+		aParent[tFriendlyName] = {
+			frameName = tFrameName,
+			RoC = "Child",
+			type = "Button",
+			obj = _G[tFrameName],
+			textFirstLine = tFrst,
+			textFull = tFll,
+			childs = {},
+			func = _G[tFrameName]:GetScript("OnClick"),
+			click = true,
+		}
+	end
 
-   local tFrameName = "ItemTextNextPageButton"
-   if _G[tFrameName]:IsShown() == true  then
-      local tFriendlyName = L["Next"]
-      local tFrst, tFll = tFriendlyName, ""
-      table.insert(aParent, tFriendlyName)
-      aParent[tFriendlyName] = {
-         frameName = tFrameName,
-         RoC = "Child",
-         type = "Button",
-         obj = _G[tFrameName],
-         textFirstLine = tFrst,
-         textFull = tFll,
-         childs = {},
-         func = _G[tFrameName]:GetScript("OnClick"),
-         click = true,
-      }
-   end
+	local tFrameName = "ItemTextNextPageButton"
+	if _G[tFrameName]:IsShown() == true  then
+		local tFriendlyName = L["Next"]
+		local tFrst, tFll = tFriendlyName, ""
+		table.insert(aParent, tFriendlyName)
+		aParent[tFriendlyName] = {
+			frameName = tFrameName,
+			RoC = "Child",
+			type = "Button",
+			obj = _G[tFrameName],
+			textFirstLine = tFrst,
+			textFull = tFll,
+			childs = {},
+			func = _G[tFrameName]:GetScript("OnClick"),
+			click = true,
+		}
+	end
 end
 
 -----------------------------------------------------------------------------------------------------------------------------------------------------
 function SkuCore:GossipFrame(aParentChilds)
 
-   local dtc = { _G["GossipGreetingScrollChildFrame"]:GetRegions() }
-   for x = 1, #dtc do
-      if dtc[x].GetText then
-         local tText = dtc[x]:GetText()
-         if tText then
-            local tFrameName = "GossipText"
-            local tFriendlyName = tText
-            local tFrst, tFll = ItemName_helper(tText)
-            table.insert(aParentChilds, tFriendlyName)
-            aParentChilds[tFriendlyName] = {
-               frameName = tFrameName,
-               RoC = "Child",
-               type = "FontString",
-               obj = _G[tFrameName],
-               textFirstLine = tFrst,
-               textFull = tFll,
-               childs = {},
-            }  
-         end
-      end
-   end
+	local dtc = { _G["GossipGreetingScrollChildFrame"]:GetRegions() }
+	for x = 1, #dtc do
+		if dtc[x].GetText then
+			local tText = dtc[x]:GetText()
+			if tText then
+				local tFrameName = "GossipText"
+				local tFriendlyName = tText
+				local tFrst, tFll = ItemName_helper(tText)
+				table.insert(aParentChilds, tFriendlyName)
+				aParentChilds[tFriendlyName] = {
+					frameName = tFrameName,
+					RoC = "Child",
+					type = "FontString",
+					obj = _G[tFrameName],
+					textFirstLine = tFrst,
+					textFull = tFll,
+					childs = {},
+				}  
+			end
+		end
+	end
 
 
-   local tIconStrings = {
-      [132048] = L["Accepted Quest"],
-      [132049] = L["Available Quest"],
-   }
+	local tIconStrings = {
+		[132048] = L["Accepted Quest"],
+		[132049] = L["Available Quest"],
+	}
 
-   for x = 1, GossipFrame.buttonIndex - 1 do
-      local tFrameName = "GossipTitleButton"..x
-      if _G[tFrameName] then
-         if _G[tFrameName]:IsShown() == true  then
-            if _G[tFrameName]:GetText() then
-               local tFriendlyName = unescape(_G[tFrameName]:GetText())
-               if _G["GossipTitleButton"..x.."GossipIcon"]:IsShown() == true then
-                  tFriendlyName = (tIconStrings[_G["GossipTitleButton"..x.."GossipIcon"]:GetTextureFileID()] or "").." "..unescape(_G[tFrameName]:GetText())
-               end
-               local tText, tFullText = "", ""
-               if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-                  table.insert(aParentChilds, tFriendlyName)
-                  aParentChilds[tFriendlyName] = {
-                     frameName = tFrameName,
-                     RoC = "Child",
-                     type = "Button",
-                     obj = _G[tFrameName],
-                     textFirstLine = tFriendlyName,
-                     textFull = "",
-                     childs = {},
-                     func = _G[tFrameName]:GetScript("OnClick"),
-                     click = true,
-                  } 
-               end
-            end
-         end
-      end
-   end
+	for x = 1, GossipFrame.buttonIndex - 1 do
+		local tFrameName = "GossipTitleButton"..x
+		if _G[tFrameName] then
+			if _G[tFrameName]:IsShown() == true  then
+				if _G[tFrameName]:GetText() then
+					local tFriendlyName = unescape(_G[tFrameName]:GetText())
+					if _G["GossipTitleButton"..x.."GossipIcon"]:IsShown() == true then
+						tFriendlyName = (tIconStrings[_G["GossipTitleButton"..x.."GossipIcon"]:GetTextureFileID()] or "").." "..unescape(_G[tFrameName]:GetText())
+					end
+					local tText, tFullText = "", ""
+					if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+						table.insert(aParentChilds, tFriendlyName)
+						aParentChilds[tFriendlyName] = {
+							frameName = tFrameName,
+							RoC = "Child",
+							type = "Button",
+							obj = _G[tFrameName],
+							textFirstLine = tFriendlyName,
+							textFull = "",
+							childs = {},
+							func = _G[tFrameName]:GetScript("OnClick"),
+							click = true,
+						} 
+					end
+				end
+			end
+		end
+	end
 end
 
 
@@ -1215,575 +1215,575 @@ end
 function SkuCore:QuestFrame(aParentChilds)
 
 
-   local function QuestInfoRewardsFrameHelper(aParent, aInfoOnly)
-      if QuestInfoRewardsFrame.ItemChooseText:IsVisible() == true or QuestInfoRewardsFrame.ItemReceiveText:IsVisible() == true or (QuestInfoMoneyFrame:IsVisible() == true and QuestInfoMoneyFrame:IsVisible() == true and QuestInfoMoneyFrame.staticMoney) then
-         local tFrameName = "QuestInfoRewardsFrame"
-         local tFriendlyName = L["Rewards"]
-         local tFrst, tFll = tFriendlyName, ""
-         table.insert(aParent, tFriendlyName)
-         aParent[tFriendlyName] = {
-            frameName = tFrameName,
-            RoC = "Child",
-            type = "Button",
-            obj = _G[tFrameName],
-            textFirstLine = tFrst,
-            textFull = tFll,
-            childs = {},
-         }
+	local function QuestInfoRewardsFrameHelper(aParent, aInfoOnly)
+		if QuestInfoRewardsFrame.ItemChooseText:IsVisible() == true or QuestInfoRewardsFrame.ItemReceiveText:IsVisible() == true or (QuestInfoMoneyFrame:IsVisible() == true and QuestInfoMoneyFrame:IsVisible() == true and QuestInfoMoneyFrame.staticMoney) then
+			local tFrameName = "QuestInfoRewardsFrame"
+			local tFriendlyName = L["Rewards"]
+			local tFrst, tFll = tFriendlyName, ""
+			table.insert(aParent, tFriendlyName)
+			aParent[tFriendlyName] = {
+				frameName = tFrameName,
+				RoC = "Child",
+				type = "Button",
+				obj = _G[tFrameName],
+				textFirstLine = tFrst,
+				textFull = tFll,
+				childs = {},
+			}
 
-         local tTaken = {}
-         local tQuestInfoRewardsFrameChilds = aParent[tFriendlyName].childs
+			local tTaken = {}
+			local tQuestInfoRewardsFrameChilds = aParent[tFriendlyName].childs
 
-         if QuestInfoRewardsFrame.ItemChooseText then
-            if QuestInfoRewardsFrame.ItemChooseText:IsVisible() == true then
-               local tText = QuestInfoRewardsFrame.ItemChooseText:GetText()
-               local tFrst, tFll = ItemName_helper(tText)
-               local tFriendlyName = tFrst
-               table.insert(tQuestInfoRewardsFrameChilds, tFriendlyName)
-               tQuestInfoRewardsFrameChilds[tFriendlyName] = {
-                  frameName = tFrameName,
-                  RoC = "Child",
-                  type = "FontString",
-                  obj = _G[tFrameName],
-                  textFirstLine = tFrst,
-                  textFull = tFll,
-                  childs = {},
-               } 
+			if QuestInfoRewardsFrame.ItemChooseText then
+				if QuestInfoRewardsFrame.ItemChooseText:IsVisible() == true then
+					local tText = QuestInfoRewardsFrame.ItemChooseText:GetText()
+					local tFrst, tFll = ItemName_helper(tText)
+					local tFriendlyName = tFrst
+					table.insert(tQuestInfoRewardsFrameChilds, tFriendlyName)
+					tQuestInfoRewardsFrameChilds[tFriendlyName] = {
+						frameName = tFrameName,
+						RoC = "Child",
+						type = "FontString",
+						obj = _G[tFrameName],
+						textFirstLine = tFrst,
+						textFull = tFll,
+						childs = {},
+					} 
 
-               for x = 1, 10 do
-                  local tFrameName = "QuestInfoRewardsFrameQuestInfoItem"..x
-                  if _G[tFrameName] then
-                     if _G[tFrameName]:IsVisible() == true then
-                        local tText, tFullText = GetButtonTooltipLines(_G[tFrameName])
-                        if tText then
-                           tTaken[x] = true
-                           tText = tText.." "..(_G[tFrameName].count or "")
-                           local tFriendlyName = unescape(tText)
-                           if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-                              table.insert(tQuestInfoRewardsFrameChilds, tFriendlyName)
-                              tQuestInfoRewardsFrameChilds[tFriendlyName] = {
-                                 frameName = tFrameName,
-                                 RoC = "Child",
-                                 type = "Button",
-                                 obj = _G[tFrameName],
-                                 textFirstLine = tText,
-                                 textFull = tFullText,
-                                 childs = {},
-                                 func = _G[tFrameName]:GetScript("OnClick"),
-                                 click = true,
-                              } 
-                              if aInfoOnly then
-                                 tQuestInfoRewardsFrameChilds[tFriendlyName].func = nil
-                                 tQuestInfoRewardsFrameChilds[tFriendlyName].click = nil
-                              end
-                           end
-                        end
-                     end
-                  end
-               end
-            end
-         end
+					for x = 1, 10 do
+						local tFrameName = "QuestInfoRewardsFrameQuestInfoItem"..x
+						if _G[tFrameName] then
+							if _G[tFrameName]:IsVisible() == true then
+								local tText, tFullText = GetButtonTooltipLines(_G[tFrameName])
+								if tText then
+									tTaken[x] = true
+									tText = tText.." "..(_G[tFrameName].count or "")
+									local tFriendlyName = unescape(tText)
+									if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+										table.insert(tQuestInfoRewardsFrameChilds, tFriendlyName)
+										tQuestInfoRewardsFrameChilds[tFriendlyName] = {
+											frameName = tFrameName,
+											RoC = "Child",
+											type = "Button",
+											obj = _G[tFrameName],
+											textFirstLine = tText,
+											textFull = tFullText,
+											childs = {},
+											func = _G[tFrameName]:GetScript("OnClick"),
+											click = true,
+										} 
+										if aInfoOnly then
+											tQuestInfoRewardsFrameChilds[tFriendlyName].func = nil
+											tQuestInfoRewardsFrameChilds[tFriendlyName].click = nil
+										end
+									end
+								end
+							end
+						end
+					end
+				end
+			end
 
-         local tQuestInfoRewardsFrameChilds = aParent[tFriendlyName].childs
-         if QuestInfoRewardsFrame.ItemReceiveText then
-            if QuestInfoRewardsFrame.ItemReceiveText:IsVisible() == true then
-               local tText = QuestInfoRewardsFrame.ItemReceiveText:GetText()
-               local tFrst, tFll = ItemName_helper(tText)
-               local tFriendlyName = tFrst
-               table.insert(tQuestInfoRewardsFrameChilds, tFriendlyName)
-               tQuestInfoRewardsFrameChilds[tFriendlyName] = {
-                  frameName = tFrameName,
-                  RoC = "Child",
-                  type = "FontString",
-                  obj = _G[tFrameName],
-                  textFirstLine = tFrst,
-                  textFull = tFll,
-                  childs = {},
-               } 
+			local tQuestInfoRewardsFrameChilds = aParent[tFriendlyName].childs
+			if QuestInfoRewardsFrame.ItemReceiveText then
+				if QuestInfoRewardsFrame.ItemReceiveText:IsVisible() == true then
+					local tText = QuestInfoRewardsFrame.ItemReceiveText:GetText()
+					local tFrst, tFll = ItemName_helper(tText)
+					local tFriendlyName = tFrst
+					table.insert(tQuestInfoRewardsFrameChilds, tFriendlyName)
+					tQuestInfoRewardsFrameChilds[tFriendlyName] = {
+						frameName = tFrameName,
+						RoC = "Child",
+						type = "FontString",
+						obj = _G[tFrameName],
+						textFirstLine = tFrst,
+						textFull = tFll,
+						childs = {},
+					} 
 
-               for x = 1, 10 do
-                  if not tTaken[x] then
-                     local tFrameName = "QuestInfoRewardsFrameQuestInfoItem"..x
-                     if _G[tFrameName] then
-                        if _G[tFrameName]:IsVisible() == true then
-                           local tText, tFullText = GetButtonTooltipLines(_G[tFrameName])
-                           if tText then
-                              tTaken[x] = true
-                              tText = tText.." "..(_G[tFrameName].count or "")
-                              local tFriendlyName = unescape(tText)
-                              if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-                                 table.insert(tQuestInfoRewardsFrameChilds, tFriendlyName)
-                                 tQuestInfoRewardsFrameChilds[tFriendlyName] = {
-                                    frameName = tFrameName,
-                                    RoC = "Child",
-                                    type = "Button",
-                                    obj = _G[tFrameName],
-                                    textFirstLine = tText,
-                                    textFull = tFullText,
-                                    childs = {},
-                                    func = _G[tFrameName]:GetScript("OnClick"),
-                                    click = true,
-                                 } 
-                                 if aInfoOnly then
-                                    tQuestInfoRewardsFrameChilds[tFriendlyName].func = nil
-                                    tQuestInfoRewardsFrameChilds[tFriendlyName].click = nil
-                                 end
-                              end
-                           end
-                        end
-                     end
-                  end
-               end
-            end
-         end
+					for x = 1, 10 do
+						if not tTaken[x] then
+							local tFrameName = "QuestInfoRewardsFrameQuestInfoItem"..x
+							if _G[tFrameName] then
+								if _G[tFrameName]:IsVisible() == true then
+									local tText, tFullText = GetButtonTooltipLines(_G[tFrameName])
+									if tText then
+										tTaken[x] = true
+										tText = tText.." "..(_G[tFrameName].count or "")
+										local tFriendlyName = unescape(tText)
+										if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+											table.insert(tQuestInfoRewardsFrameChilds, tFriendlyName)
+											tQuestInfoRewardsFrameChilds[tFriendlyName] = {
+												frameName = tFrameName,
+												RoC = "Child",
+												type = "Button",
+												obj = _G[tFrameName],
+												textFirstLine = tText,
+												textFull = tFullText,
+												childs = {},
+												func = _G[tFrameName]:GetScript("OnClick"),
+												click = true,
+											} 
+											if aInfoOnly then
+												tQuestInfoRewardsFrameChilds[tFriendlyName].func = nil
+												tQuestInfoRewardsFrameChilds[tFriendlyName].click = nil
+											end
+										end
+									end
+								end
+							end
+						end
+					end
+				end
+			end
 
-         if QuestInfoMoneyFrame then
-            if QuestInfoMoneyFrame:IsVisible() == true then
-               if QuestInfoMoneyFrame.staticMoney then
-                  local tFrst, tFll = SkuGetCoinText(QuestInfoMoneyFrame.staticMoney, true), ""
-                  local tFriendlyName = tFrst
-                  table.insert(tQuestInfoRewardsFrameChilds, tFriendlyName)
-                  tQuestInfoRewardsFrameChilds[tFriendlyName] = {
-                     frameName = tFrameName,
-                     RoC = "Child",
-                     type = "FontString",
-                     obj = _G[tFrameName],
-                     textFirstLine = tFrst,
-                     textFull = tFll,
-                     childs = {},
-                  }
-               end
-            end
-         end   
-      end
+			if QuestInfoMoneyFrame then
+				if QuestInfoMoneyFrame:IsVisible() == true then
+					if QuestInfoMoneyFrame.staticMoney then
+						local tFrst, tFll = SkuGetCoinText(QuestInfoMoneyFrame.staticMoney, true), ""
+						local tFriendlyName = tFrst
+						table.insert(tQuestInfoRewardsFrameChilds, tFriendlyName)
+						tQuestInfoRewardsFrameChilds[tFriendlyName] = {
+							frameName = tFrameName,
+							RoC = "Child",
+							type = "FontString",
+							obj = _G[tFrameName],
+							textFirstLine = tFrst,
+							textFull = tFll,
+							childs = {},
+						}
+					end
+				end
+			end   
+		end
 
-   end
-
-
-   --QuestFrameGreetingPanel
-   if _G["QuestFrameGreetingPanel"] then 
-      if _G["QuestFrameGreetingPanel"]:IsVisible() == true then
-
-         local tFrameName = "QuestFrameGreetingPanel"
-         local tFriendlyName = L["Greeting"]
-         local tFrst, tFll = tFriendlyName, ""
-         table.insert(aParentChilds, tFriendlyName)
-         aParentChilds[tFriendlyName] = {
-            frameName = tFrameName,
-            RoC = "Child",
-            type = "Button",
-            obj = _G[tFrameName],
-            textFirstLine = tFrst,
-            textFull = tFll,
-            childs = {},
-         }  
-
-         local tGreetingChilds = aParentChilds[tFriendlyName].childs
-         local dtc = { _G["QuestGreetingScrollChildFrame"]:GetRegions() }
-         for x = 1, 1 do --#dtc do
-            if dtc[x].GetText then
-               local tText = dtc[x]:GetText()
-               if tText then
-                  local tFrameName = "GreetingText"
-                  local tFriendlyName = tText
-                  local tFrst, tFll = ItemName_helper(tText)
-                  table.insert(tGreetingChilds, tFriendlyName)
-                  tGreetingChilds[tFriendlyName] = {
-                     frameName = tFrameName,
-                     RoC = "Child",
-                     type = "FontString",
-                     obj = _G[tFrameName],
-                     textFirstLine = tFrst,
-                     textFull = tFll,
-                     childs = {},
-                  }  
-               end
-            end
-         end
-
-         local tIconStrings = {
-            [132048] = L["Accepted Quest"],
-            [132049] = L["Available Quest"],
-         }
-
-         for x = 1, 10 do
-            local tFrameName = "QuestTitleButton"..x
-            if _G[tFrameName] then
-               if _G[tFrameName]:IsVisible() == true then
-                  if _G[tFrameName]:GetText() then
-                     local tFriendlyName = unescape(_G[tFrameName]:GetText())
-                     if _G["QuestTitleButton"..x.."QuestIcon"]:IsVisible() == true  then
-                        tFriendlyName = (tIconStrings[_G["QuestTitleButton"..x.."QuestIcon"]:GetTextureFileID()] or "").." "..unescape(_G[tFrameName]:GetText())
-                     end
-                     local tText, tFullText = "", ""
-                     if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-                        table.insert(tGreetingChilds, tFriendlyName)
-                        tGreetingChilds[tFriendlyName] = {
-                           frameName = tFrameName,
-                           RoC = "Child",
-                           type = "Button",
-                           obj = _G[tFrameName],
-                           textFirstLine = tFriendlyName,
-                           textFull = "",
-                           childs = {},
-                           func = _G[tFrameName]:GetScript("OnClick"),
-                           click = true,
-                        } 
-                     end
-                  end
-               end
-            end
-         end
-      end
-   end
-
-   --QuestFrameProgressPanel
-   if _G["QuestFrameProgressPanel"] then 
-      if _G["QuestFrameProgressPanel"]:IsVisible() == true then
-         local tFrameName = "QuestFrameProgressPanel"
-         local tFriendlyName = L["Progress"]
-         local tFrst, tFll = tFriendlyName, ""
-         table.insert(aParentChilds, tFriendlyName)
-         aParentChilds[tFriendlyName] = {
-            frameName = tFrameName,
-            RoC = "Child",
-            type = "Button",
-            obj = _G[tFrameName],
-            textFirstLine = tFrst,
-            textFull = tFll,
-            childs = {},
-         }  
-
-         local tProgressChilds = aParentChilds[tFriendlyName].childs
-         local dtc = { _G["QuestProgressScrollChildFrame"]:GetRegions() }
-         for x = 1, 2 do
-            if dtc[x].GetText then
-               local tText = dtc[x]:GetText()
-               if tText then
-                  local tFrameName = "QuestInfo"
-                  local tFriendlyName = tText
-                  local tFrst, tFll = ItemName_helper(tText)
-                  table.insert(tProgressChilds, tFriendlyName)
-                  tProgressChilds[tFriendlyName] = {
-                     frameName = tFrameName,
-                     RoC = "Child",
-                     type = "FontString",
-                     obj = _G[tFrameName],
-                     textFirstLine = tFrst,
-                     textFull = tFll,
-                     childs = {},
-                  }  
-               end
-            end
-         end
-         if dtc[3]:IsVisible() == true then
-            if dtc[3].GetText then
-               local tText = dtc[3]:GetText()
-               if tText then
-                  local tFrameName = "QuestInfo"
-                  local tFriendlyName = tText
-                  local tFrst, tFll = ItemName_helper(tText)
-                  table.insert(tProgressChilds, tFriendlyName)
-                  tProgressChilds[tFriendlyName] = {
-                     frameName = tFrameName,
-                     RoC = "Child",
-                     type = "FontString",
-                     obj = _G[tFrameName],
-                     textFirstLine = tFrst,
-                     textFull = tFll,
-                     childs = {},
-                  }  
-               end
-            end
-
-            for x = 1, 10 do
-               local tFrameName = "QuestProgressItem"..x
-               if _G[tFrameName] then
-                  if _G[tFrameName]:IsVisible() == true then
-                     local tText, tFullText = GetButtonTooltipLines(_G[tFrameName])
-                     if tText then
-                        tText = tText.." "..(_G[tFrameName].count or "")
-                        local tFriendlyName = unescape(tText)
-                        --if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-                           table.insert(tProgressChilds, tFriendlyName)
-                           tProgressChilds[tFriendlyName] = {
-                              frameName = tFrameName,
-                              RoC = "Child",
-                              type = "Button",
-                              obj = _G[tFrameName],
-                              textFirstLine = tText,
-                              textFull = tFullText,
-                              childs = {},
-                              --func = _G[tFrameName]:GetScript("OnClick"),
-                              --click = true,
-                           } 
-                        --end
-                     end
-                  end
-               end
-            end
-         end
-
-         if dtc[4]:IsVisible() == true then
-            if dtc[4].GetText then
-               local tText = dtc[4]:GetText()
-               if tText then
-                  local tFrameName = "QuestInfo"
-                  local tFriendlyName = tText
-                  local tFrst, tFll = ItemName_helper(tText)
-                  table.insert(tProgressChilds, tFriendlyName)
-                  tProgressChilds[tFriendlyName] = {
-                     frameName = tFrameName,
-                     RoC = "Child",
-                     type = "FontString",
-                     obj = _G[tFrameName],
-                     textFirstLine = tFrst,
-                     textFull = tFll,
-                     childs = {},
-                  }  
-               end
-            end
-         end
-
-         local tFrameName = "QuestFrameCompleteButton"
-         if _G[tFrameName] then
-            if _G[tFrameName]:IsVisible() == true then
-               if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-                  local tFriendlyName = _G[tFrameName]:GetText()
-                  table.insert(tProgressChilds, tFriendlyName)
-                  tProgressChilds[tFriendlyName] = {
-                     frameName = tFrameName,
-                     RoC = "Child",
-                     type = "Button",
-                     obj = _G[tFrameName],
-                     textFirstLine = tFriendlyName,
-                     textFull = "",
-                     childs = {},
-                     func = _G[tFrameName]:GetScript("OnClick"),
-                     click = true,
-                  } 
-               end
-            end
-         end
-      end
-   end
-
-   --QuestFrameDetailPanel
-   if _G["QuestFrameDetailPanel"] then 
-      if _G["QuestFrameDetailPanel"]:IsVisible() == true then
-         local tFrameName = "QuestFrameDetailPanel"
-         local tFriendlyName = L["Detail"]
-         local tFrst, tFll = tFriendlyName, ""
-         table.insert(aParentChilds, tFriendlyName)
-         aParentChilds[tFriendlyName] = {
-            frameName = tFrameName,
-            RoC = "Child",
-            type = "Button",
-            obj = _G[tFrameName],
-            textFirstLine = tFrst,
-            textFull = tFll,
-            childs = {},
-         }  
+	end
 
 
-         local tDetailChilds = aParentChilds[tFriendlyName].childs
-         local dtc = { _G["QuestDetailScrollChildFrame"]:GetRegions() }
+	--QuestFrameGreetingPanel
+	if _G["QuestFrameGreetingPanel"] then 
+		if _G["QuestFrameGreetingPanel"]:IsVisible() == true then
 
-         local tFrameName = "QuestInfoTitleHeader"
-         if _G[tFrameName] then
-            local tText = _G[tFrameName]:GetText()
-            if tText then
-               local tFriendlyName = tText
-               local tFrst, tFll = ItemName_helper(tText)
-               table.insert(tDetailChilds, tFriendlyName)
-               tDetailChilds[tFriendlyName] = {
-                  frameName = tFrameName,
-                  RoC = "Child",
-                  type = "FontString",
-                  obj = _G[tFrameName],
-                  textFirstLine = tFrst,
-                  textFull = tFll,
-                  childs = {},
-               }  
-            end
-         end
-         local tFrameName = "QuestInfoDescriptionText"
-         if _G[tFrameName] then
-            local tText = _G[tFrameName]:GetText()
-            if tText then
-               local tFriendlyName = tText
-               local tFrst, tFll = ItemName_helper(tText)
-               table.insert(tDetailChilds, tFriendlyName)
-               tDetailChilds[tFriendlyName] = {
-                  frameName = tFrameName,
-                  RoC = "Child",
-                  type = "FontString",
-                  obj = _G[tFrameName],
-                  textFirstLine = tFrst,
-                  textFull = tFll,
-                  childs = {},
-               }  
-            end
-         end
+			local tFrameName = "QuestFrameGreetingPanel"
+			local tFriendlyName = L["Greeting"]
+			local tFrst, tFll = tFriendlyName, ""
+			table.insert(aParentChilds, tFriendlyName)
+			aParentChilds[tFriendlyName] = {
+				frameName = tFrameName,
+				RoC = "Child",
+				type = "Button",
+				obj = _G[tFrameName],
+				textFirstLine = tFrst,
+				textFull = tFll,
+				childs = {},
+			}  
 
-         local tFrameName = "QuestInfoObjectivesHeader"
-         if _G[tFrameName] then
-            local tText = _G[tFrameName]:GetText()
-            if tText then
-               local tFriendlyName = tText
-               local tFrst, tFll = ItemName_helper(tText)
-               table.insert(tDetailChilds, tFriendlyName)
-               tDetailChilds[tFriendlyName] = {
-                  frameName = tFrameName,
-                  RoC = "Child",
-                  type = "FontString",
-                  obj = _G[tFrameName],
-                  textFirstLine = tFrst,
-                  textFull = tFll,
-                  childs = {},
-               }  
-            end
-         end
-         local tFrameName = "QuestInfoObjectivesText"
-         if _G[tFrameName] then
-            local tText = _G[tFrameName]:GetText()
-            if tText then
-               local tFriendlyName = tText
-               local tFrst, tFll = ItemName_helper(tText)
-               table.insert(tDetailChilds, tFriendlyName)
-               tDetailChilds[tFriendlyName] = {
-                  frameName = tFrameName,
-                  RoC = "Child",
-                  type = "FontString",
-                  obj = _G[tFrameName],
-                  textFirstLine = tFrst,
-                  textFull = tFll,
-                  childs = {},
-               }  
-            end
-         end
+			local tGreetingChilds = aParentChilds[tFriendlyName].childs
+			local dtc = { _G["QuestGreetingScrollChildFrame"]:GetRegions() }
+			for x = 1, 1 do --#dtc do
+				if dtc[x].GetText then
+					local tText = dtc[x]:GetText()
+					if tText then
+						local tFrameName = "GreetingText"
+						local tFriendlyName = tText
+						local tFrst, tFll = ItemName_helper(tText)
+						table.insert(tGreetingChilds, tFriendlyName)
+						tGreetingChilds[tFriendlyName] = {
+							frameName = tFrameName,
+							RoC = "Child",
+							type = "FontString",
+							obj = _G[tFrameName],
+							textFirstLine = tFrst,
+							textFull = tFll,
+							childs = {},
+						}  
+					end
+				end
+			end
 
-         --rewards
-         if _G["QuestInfoRewardsFrame"] then 
-            QuestInfoRewardsFrameHelper(tDetailChilds, true)
-         end
+			local tIconStrings = {
+				[132048] = L["Accepted Quest"],
+				[132049] = L["Available Quest"],
+			}
 
-         local tFrameName = "QuestFrameAcceptButton"
-         local tFriendlyName = L["Accept"]
-         local tFrst, tFll = tFriendlyName, ""
-         if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-            table.insert(tDetailChilds, tFriendlyName)
-            tDetailChilds[tFriendlyName] = {
-               frameName = tFrameName,
-               RoC = "Child",
-               type = "Button",
-               obj = _G[tFrameName],
-               textFirstLine = tFrst,
-               textFull = tFll,
-               childs = {},
-               func = _G[tFrameName]:GetScript("OnClick"),
-               click = true,
-            }  
-         end
-         local tFrameName = "QuestFrameDeclineButton"
-         local tFriendlyName = L["Ablehnen"]
-         local tFrst, tFll = tFriendlyName, ""
-         if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
-            table.insert(tDetailChilds, tFriendlyName)
-            tDetailChilds[tFriendlyName] = {
-               frameName = tFrameName,
-               RoC = "Child",
-               type = "Button",
-               obj = _G[tFrameName],
-               textFirstLine = tFrst,
-               textFull = tFll,
-               childs = {},
-               func = _G[tFrameName]:GetScript("OnClick"),
-               click = true,
-            }  			
-         end
-      end
-   end
+			for x = 1, 10 do
+				local tFrameName = "QuestTitleButton"..x
+				if _G[tFrameName] then
+					if _G[tFrameName]:IsVisible() == true then
+						if _G[tFrameName]:GetText() then
+							local tFriendlyName = unescape(_G[tFrameName]:GetText())
+							if _G["QuestTitleButton"..x.."QuestIcon"]:IsVisible() == true  then
+								tFriendlyName = (tIconStrings[_G["QuestTitleButton"..x.."QuestIcon"]:GetTextureFileID()] or "").." "..unescape(_G[tFrameName]:GetText())
+							end
+							local tText, tFullText = "", ""
+							if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+								table.insert(tGreetingChilds, tFriendlyName)
+								tGreetingChilds[tFriendlyName] = {
+									frameName = tFrameName,
+									RoC = "Child",
+									type = "Button",
+									obj = _G[tFrameName],
+									textFirstLine = tFriendlyName,
+									textFull = "",
+									childs = {},
+									func = _G[tFrameName]:GetScript("OnClick"),
+									click = true,
+								} 
+							end
+						end
+					end
+				end
+			end
+		end
+	end
+
+	--QuestFrameProgressPanel
+	if _G["QuestFrameProgressPanel"] then 
+		if _G["QuestFrameProgressPanel"]:IsVisible() == true then
+			local tFrameName = "QuestFrameProgressPanel"
+			local tFriendlyName = L["Progress"]
+			local tFrst, tFll = tFriendlyName, ""
+			table.insert(aParentChilds, tFriendlyName)
+			aParentChilds[tFriendlyName] = {
+				frameName = tFrameName,
+				RoC = "Child",
+				type = "Button",
+				obj = _G[tFrameName],
+				textFirstLine = tFrst,
+				textFull = tFll,
+				childs = {},
+			}  
+
+			local tProgressChilds = aParentChilds[tFriendlyName].childs
+			local dtc = { _G["QuestProgressScrollChildFrame"]:GetRegions() }
+			for x = 1, 2 do
+				if dtc[x].GetText then
+					local tText = dtc[x]:GetText()
+					if tText then
+						local tFrameName = "QuestInfo"
+						local tFriendlyName = tText
+						local tFrst, tFll = ItemName_helper(tText)
+						table.insert(tProgressChilds, tFriendlyName)
+						tProgressChilds[tFriendlyName] = {
+							frameName = tFrameName,
+							RoC = "Child",
+							type = "FontString",
+							obj = _G[tFrameName],
+							textFirstLine = tFrst,
+							textFull = tFll,
+							childs = {},
+						}  
+					end
+				end
+			end
+			if dtc[3]:IsVisible() == true then
+				if dtc[3].GetText then
+					local tText = dtc[3]:GetText()
+					if tText then
+						local tFrameName = "QuestInfo"
+						local tFriendlyName = tText
+						local tFrst, tFll = ItemName_helper(tText)
+						table.insert(tProgressChilds, tFriendlyName)
+						tProgressChilds[tFriendlyName] = {
+							frameName = tFrameName,
+							RoC = "Child",
+							type = "FontString",
+							obj = _G[tFrameName],
+							textFirstLine = tFrst,
+							textFull = tFll,
+							childs = {},
+						}  
+					end
+				end
+
+				for x = 1, 10 do
+					local tFrameName = "QuestProgressItem"..x
+					if _G[tFrameName] then
+						if _G[tFrameName]:IsVisible() == true then
+							local tText, tFullText = GetButtonTooltipLines(_G[tFrameName])
+							if tText then
+								tText = tText.." "..(_G[tFrameName].count or "")
+								local tFriendlyName = unescape(tText)
+								--if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+									table.insert(tProgressChilds, tFriendlyName)
+									tProgressChilds[tFriendlyName] = {
+										frameName = tFrameName,
+										RoC = "Child",
+										type = "Button",
+										obj = _G[tFrameName],
+										textFirstLine = tText,
+										textFull = tFullText,
+										childs = {},
+										--func = _G[tFrameName]:GetScript("OnClick"),
+										--click = true,
+									} 
+								--end
+							end
+						end
+					end
+				end
+			end
+
+			if dtc[4]:IsVisible() == true then
+				if dtc[4].GetText then
+					local tText = dtc[4]:GetText()
+					if tText then
+						local tFrameName = "QuestInfo"
+						local tFriendlyName = tText
+						local tFrst, tFll = ItemName_helper(tText)
+						table.insert(tProgressChilds, tFriendlyName)
+						tProgressChilds[tFriendlyName] = {
+							frameName = tFrameName,
+							RoC = "Child",
+							type = "FontString",
+							obj = _G[tFrameName],
+							textFirstLine = tFrst,
+							textFull = tFll,
+							childs = {},
+						}  
+					end
+				end
+			end
+
+			local tFrameName = "QuestFrameCompleteButton"
+			if _G[tFrameName] then
+				if _G[tFrameName]:IsVisible() == true then
+					if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+						local tFriendlyName = _G[tFrameName]:GetText()
+						table.insert(tProgressChilds, tFriendlyName)
+						tProgressChilds[tFriendlyName] = {
+							frameName = tFrameName,
+							RoC = "Child",
+							type = "Button",
+							obj = _G[tFrameName],
+							textFirstLine = tFriendlyName,
+							textFull = "",
+							childs = {},
+							func = _G[tFrameName]:GetScript("OnClick"),
+							click = true,
+						} 
+					end
+				end
+			end
+		end
+	end
+
+	--QuestFrameDetailPanel
+	if _G["QuestFrameDetailPanel"] then 
+		if _G["QuestFrameDetailPanel"]:IsVisible() == true then
+			local tFrameName = "QuestFrameDetailPanel"
+			local tFriendlyName = L["Detail"]
+			local tFrst, tFll = tFriendlyName, ""
+			table.insert(aParentChilds, tFriendlyName)
+			aParentChilds[tFriendlyName] = {
+				frameName = tFrameName,
+				RoC = "Child",
+				type = "Button",
+				obj = _G[tFrameName],
+				textFirstLine = tFrst,
+				textFull = tFll,
+				childs = {},
+			}  
 
 
-   --QuestFrameRewardPanel
-   if _G["QuestFrameRewardPanel"] then 
-      if _G["QuestFrameRewardPanel"]:IsVisible() == true then
-         local tFrameName = "QuestFrameRewardPanel"
-         local tFriendlyName = L["Abgabe"]
-         local tFrst, tFll = tFriendlyName, ""
-         table.insert(aParentChilds, tFriendlyName)
-         aParentChilds[tFriendlyName] = {
-            frameName = tFrameName,
-            RoC = "Child",
-            type = "Button",
-            obj = _G[tFrameName],
-            textFirstLine = tFrst,
-            textFull = tFll,
-            childs = {},
-         }  
+			local tDetailChilds = aParentChilds[tFriendlyName].childs
+			local dtc = { _G["QuestDetailScrollChildFrame"]:GetRegions() }
 
-         local tDetailChilds = aParentChilds[tFriendlyName].childs
+			local tFrameName = "QuestInfoTitleHeader"
+			if _G[tFrameName] then
+				local tText = _G[tFrameName]:GetText()
+				if tText then
+					local tFriendlyName = tText
+					local tFrst, tFll = ItemName_helper(tText)
+					table.insert(tDetailChilds, tFriendlyName)
+					tDetailChilds[tFriendlyName] = {
+						frameName = tFrameName,
+						RoC = "Child",
+						type = "FontString",
+						obj = _G[tFrameName],
+						textFirstLine = tFrst,
+						textFull = tFll,
+						childs = {},
+					}  
+				end
+			end
+			local tFrameName = "QuestInfoDescriptionText"
+			if _G[tFrameName] then
+				local tText = _G[tFrameName]:GetText()
+				if tText then
+					local tFriendlyName = tText
+					local tFrst, tFll = ItemName_helper(tText)
+					table.insert(tDetailChilds, tFriendlyName)
+					tDetailChilds[tFriendlyName] = {
+						frameName = tFrameName,
+						RoC = "Child",
+						type = "FontString",
+						obj = _G[tFrameName],
+						textFirstLine = tFrst,
+						textFull = tFll,
+						childs = {},
+					}  
+				end
+			end
 
-         local tFrameName = "QuestInfoTitleHeader"
-         if _G[tFrameName] then
-            local tText = _G[tFrameName]:GetText()
-            if tText then
-               local tFriendlyName = tText
-               local tFrst, tFll = ItemName_helper(tText)
-               table.insert(tDetailChilds, tFriendlyName)
-               tDetailChilds[tFriendlyName] = {
-                  frameName = tFrameName,
-                  RoC = "Child",
-                  type = "FontString",
-                  obj = _G[tFrameName],
-                  textFirstLine = tFrst,
-                  textFull = tFll,
-                  childs = {},
-               }  
-            end
-         end
-         local tFrameName = "QuestInfoRewardText"
-         if _G[tFrameName] then
-            local tText = _G[tFrameName]:GetText()
-            if tText then
-               local tFriendlyName = tText
-               local tFrst, tFll = ItemName_helper(tText)
-               table.insert(tDetailChilds, tFriendlyName)
-               tDetailChilds[tFriendlyName] = {
-                  frameName = tFrameName,
-                  RoC = "Child",
-                  type = "FontString",
-                  obj = _G[tFrameName],
-                  textFirstLine = tFrst,
-                  textFull = tFll,
-                  childs = {},
-               }  
-            end
-         end
+			local tFrameName = "QuestInfoObjectivesHeader"
+			if _G[tFrameName] then
+				local tText = _G[tFrameName]:GetText()
+				if tText then
+					local tFriendlyName = tText
+					local tFrst, tFll = ItemName_helper(tText)
+					table.insert(tDetailChilds, tFriendlyName)
+					tDetailChilds[tFriendlyName] = {
+						frameName = tFrameName,
+						RoC = "Child",
+						type = "FontString",
+						obj = _G[tFrameName],
+						textFirstLine = tFrst,
+						textFull = tFll,
+						childs = {},
+					}  
+				end
+			end
+			local tFrameName = "QuestInfoObjectivesText"
+			if _G[tFrameName] then
+				local tText = _G[tFrameName]:GetText()
+				if tText then
+					local tFriendlyName = tText
+					local tFrst, tFll = ItemName_helper(tText)
+					table.insert(tDetailChilds, tFriendlyName)
+					tDetailChilds[tFriendlyName] = {
+						frameName = tFrameName,
+						RoC = "Child",
+						type = "FontString",
+						obj = _G[tFrameName],
+						textFirstLine = tFrst,
+						textFull = tFll,
+						childs = {},
+					}  
+				end
+			end
 
-         if QuestInfoRewardsFrame.ItemChooseText:IsVisible() == true or QuestInfoRewardsFrame.ItemReceiveText:IsVisible() == true or (QuestInfoMoneyFrame:IsVisible() == true and QuestInfoMoneyFrame:IsVisible() == true and QuestInfoMoneyFrame.staticMoney) then
-            QuestInfoRewardsFrameHelper(tDetailChilds)
-         end
-         
-         local tFrameName = "QuestFrameCompleteQuestButton"
-         local tFriendlyName = L["Complete"]
-         local tFrst, tFll = tFriendlyName, ""
-         table.insert(tDetailChilds, tFriendlyName)
-         tDetailChilds[tFriendlyName] = {
-            frameName = tFrameName,
-            RoC = "Child",
-            type = "Button",
-            obj = _G[tFrameName],
-            textFirstLine = tFrst,
-            textFull = tFll,
-            childs = {},
-            func = _G[tFrameName]:GetScript("OnClick"),
-            click = true,
-         }  
-			         
-      end
-   end
+			--rewards
+			if _G["QuestInfoRewardsFrame"] then 
+				QuestInfoRewardsFrameHelper(tDetailChilds, true)
+			end
+
+			local tFrameName = "QuestFrameAcceptButton"
+			local tFriendlyName = L["Accept"]
+			local tFrst, tFll = tFriendlyName, ""
+			if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+				table.insert(tDetailChilds, tFriendlyName)
+				tDetailChilds[tFriendlyName] = {
+					frameName = tFrameName,
+					RoC = "Child",
+					type = "Button",
+					obj = _G[tFrameName],
+					textFirstLine = tFrst,
+					textFull = tFll,
+					childs = {},
+					func = _G[tFrameName]:GetScript("OnClick"),
+					click = true,
+				}  
+			end
+			local tFrameName = "QuestFrameDeclineButton"
+			local tFriendlyName = L["Ablehnen"]
+			local tFrst, tFll = tFriendlyName, ""
+			if _G[tFrameName]:IsEnabled() == true then --IsMouseClickEnabled()
+				table.insert(tDetailChilds, tFriendlyName)
+				tDetailChilds[tFriendlyName] = {
+					frameName = tFrameName,
+					RoC = "Child",
+					type = "Button",
+					obj = _G[tFrameName],
+					textFirstLine = tFrst,
+					textFull = tFll,
+					childs = {},
+					func = _G[tFrameName]:GetScript("OnClick"),
+					click = true,
+				}  			
+			end
+		end
+	end
+
+
+	--QuestFrameRewardPanel
+	if _G["QuestFrameRewardPanel"] then 
+		if _G["QuestFrameRewardPanel"]:IsVisible() == true then
+			local tFrameName = "QuestFrameRewardPanel"
+			local tFriendlyName = L["Abgabe"]
+			local tFrst, tFll = tFriendlyName, ""
+			table.insert(aParentChilds, tFriendlyName)
+			aParentChilds[tFriendlyName] = {
+				frameName = tFrameName,
+				RoC = "Child",
+				type = "Button",
+				obj = _G[tFrameName],
+				textFirstLine = tFrst,
+				textFull = tFll,
+				childs = {},
+			}  
+
+			local tDetailChilds = aParentChilds[tFriendlyName].childs
+
+			local tFrameName = "QuestInfoTitleHeader"
+			if _G[tFrameName] then
+				local tText = _G[tFrameName]:GetText()
+				if tText then
+					local tFriendlyName = tText
+					local tFrst, tFll = ItemName_helper(tText)
+					table.insert(tDetailChilds, tFriendlyName)
+					tDetailChilds[tFriendlyName] = {
+						frameName = tFrameName,
+						RoC = "Child",
+						type = "FontString",
+						obj = _G[tFrameName],
+						textFirstLine = tFrst,
+						textFull = tFll,
+						childs = {},
+					}  
+				end
+			end
+			local tFrameName = "QuestInfoRewardText"
+			if _G[tFrameName] then
+				local tText = _G[tFrameName]:GetText()
+				if tText then
+					local tFriendlyName = tText
+					local tFrst, tFll = ItemName_helper(tText)
+					table.insert(tDetailChilds, tFriendlyName)
+					tDetailChilds[tFriendlyName] = {
+						frameName = tFrameName,
+						RoC = "Child",
+						type = "FontString",
+						obj = _G[tFrameName],
+						textFirstLine = tFrst,
+						textFull = tFll,
+						childs = {},
+					}  
+				end
+			end
+
+			if QuestInfoRewardsFrame.ItemChooseText:IsVisible() == true or QuestInfoRewardsFrame.ItemReceiveText:IsVisible() == true or (QuestInfoMoneyFrame:IsVisible() == true and QuestInfoMoneyFrame:IsVisible() == true and QuestInfoMoneyFrame.staticMoney) then
+				QuestInfoRewardsFrameHelper(tDetailChilds)
+			end
+			
+			local tFrameName = "QuestFrameCompleteQuestButton"
+			local tFriendlyName = L["Complete"]
+			local tFrst, tFll = tFriendlyName, ""
+			table.insert(tDetailChilds, tFriendlyName)
+			tDetailChilds[tFriendlyName] = {
+				frameName = tFrameName,
+				RoC = "Child",
+				type = "Button",
+				obj = _G[tFrameName],
+				textFirstLine = tFrst,
+				textFull = tFll,
+				childs = {},
+				func = _G[tFrameName]:GetScript("OnClick"),
+				click = true,
+			}  
+						
+		end
+	end
 
 
 

--- a/SkuCore/LocalMenu.lua
+++ b/SkuCore/LocalMenu.lua
@@ -278,14 +278,15 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 	local tBagResults = {}
 	local inventoryTooltipTextCache = {}
 
-   for frameNo = 1, 8 do
-      for itemNo = 1, 36 do
-         local tFrameName = "ContainerFrame"..frameNo.."Item"..itemNo
-         if _G[tFrameName] then
-            if _G[tFrameName].GetBag then
-               if _G[tFrameName].bag >= 0 then
-                  local bagId = _G[tFrameName]:GetBag() + 1
-                  local slotId = _G[tFrameName]:GetID()
+	for frameNo = 1, 8 do
+		for itemNo = 1, 36 do
+			local containerFrameName = "ContainerFrame" .. frameNo .. "Item" .. itemNo
+			local containerFrame = _G[containerFrameName]
+			if containerFrame then
+				if containerFrame.GetBag then
+					if containerFrame.bag >= 0 then
+						local bagId = containerFrame:GetBag() + 1
+						local slotId = containerFrame:GetID()
 
                   if bagId > 0 then
                      tCurrentBag = bagId
@@ -295,10 +296,10 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
                         local tText, tFullText = L["Bag"].." "..bagId, ""
                         table.insert(aParentChilds, tFriendlyName)
                         aParentChilds[tFriendlyName] = {
-                           frameName = tFrameName,
+                           frameName = containerFrameName,
                            RoC = "Child",
                            type = "Button",
-                           obj = _G[tFrameName],
+                           obj = containerFrame,
                            textFirstLine = tFriendlyName,
                            textFull = "",
                            noMenuNumbers = true,
@@ -311,12 +312,12 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 
                   local tFriendlyName = L["Bag"]..bagId.."-"..slotId
                   local tText, tFullText = L["Empty"], ""
-                  if _G[tFrameName]:IsEnabled() == true then
+                  if containerFrame:IsEnabled() == true then
                      aParentChilds[tFriendlyName] = {
-                        frameName = tFrameName,
+                        frameName = containerFrameName,
                         RoC = "Child",
                         type = "Button",
-                        obj = _G[tFrameName],
+                        obj = containerFrame,
                         textFirstLine = tText,
                         textFull = "",
                         noMenuNumbers = true,
@@ -327,7 +328,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
                         if aParentChilds[tFriendlyName].obj:GetObjectType() == "Button" then
                            aParentChilds[tFriendlyName].func = aParentChilds[tFriendlyName].obj:GetScript("OnClick")
                         end
-                        aParentChilds[tFriendlyName].containerFrameName = tFrameName
+                        aParentChilds[tFriendlyName].containerFrameName = containerFrameName
                         aParentChilds[tFriendlyName].onActionFunc = function(self, aTable, aChildName)
 
                         end
@@ -382,31 +383,31 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
                      
                      
 
-                     if _G[tFrameName.."Count"] and not _G[tFrameName].info then
-                        if aParentChilds[tFriendlyName] and _G[tFrameName.."Count"]:GetText() then
+                     if _G[containerFrameName .. "Count"] and not containerFrame.info then
+                        if aParentChilds[tFriendlyName] and _G[containerFrameName .. "Count"]:GetText() then
                            if not string.find(aParentChilds[tFriendlyName].textFirstLine, L["Empty"].." ") then
-                              aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine.." ".._G[tFrameName.."Count"]:GetText()
+                              aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine .. " " .. _G[containerFrameName .. "Count"]:GetText()
                            else
                               aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine
                            end
                         end
                      end
-                     if aParentChilds[tFriendlyName] and string.find(tFrameName, "ContainerFrame") then
+                     if aParentChilds[tFriendlyName] and string.find(containerFrameName, "ContainerFrame") then
                         if aParentChilds[tFriendlyName].textFirstLine then
                            aParentChilds[tFriendlyName].textFirstLine = (#tBagResults[bagId].childs + 1).." "..aParentChilds[tFriendlyName].textFirstLine
                            tEmptyCounter = tEmptyCounter + 1
                         end
                      end
-                     if _G[tFrameName.."Count"] and aParentChilds[tFriendlyName] then
-                        aParentChilds[tFriendlyName].stackSize = _G[tFrameName.."Count"]:GetText()
+                     if _G[containerFrameName .. "Count"] and aParentChilds[tFriendlyName] then
+                        aParentChilds[tFriendlyName].stackSize = _G[containerFrameName .. "Count"]:GetText()
                      end
-                     if _G[tFrameName].info then
-                        aParentChilds[tFriendlyName].itemId = _G[tFrameName].info.id
-                        if not _G[tFrameName].info.count then
+                     if containerFrame.info then
+                        aParentChilds[tFriendlyName].itemId = containerFrame.info.id
+                        if not containerFrame.info.count then
                            aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine
                         else
-                           if not string.find(aParentChilds[tFriendlyName].textFirstLine, L["Empty"].." ") and _G[tFrameName].info.count > 1 then
-                              aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine.." ".._G[tFrameName].info.count
+                           if not string.find(aParentChilds[tFriendlyName].textFirstLine, L["Empty"] .. " ") and containerFrame.info.count > 1 then
+                              aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine .. " " .. containerFrame.info.count
                            else
                               aParentChilds[tFriendlyName].textFirstLine = aParentChilds[tFriendlyName].textFirstLine
                            end

--- a/SkuCore/LocalMenu.lua
+++ b/SkuCore/LocalMenu.lua
@@ -396,7 +396,6 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 							end
 							if bagItemButton and string.find(containerFrameName, "ContainerFrame") then
 								if bagItemButton.textFirstLine then
-									bagItemButton.originalTextFirstLine = bagItemButton.textFirstLine
 									bagItemButton.textFirstLine = (#tBagResults[bagId].childs + 1) .. " " .. bagItemButton.textFirstLine
 									tEmptyCounter = tEmptyCounter + 1
 								end
@@ -421,8 +420,14 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 						
 						table.insert(tBagResults[bagId].childs, aParentChilds[bagItemSlotName])
 						if not string.find(aParentChilds[bagItemSlotName].textFirstLine, L["Empty"]) then
-							table.insert(allBagItems, aParentChilds[bagItemSlotName])
-							allBagItems[aParentChilds[bagItemSlotName]] = aParentChilds[bagItemSlotName]
+							-- put a copy in all items that doesn't include the numbering in the textFirstLine
+							copy = {}
+							for k, v in pairs(aParentChilds[bagItemSlotName]) do
+								copy[k] = v
+							end
+							copy.textFirstLine = string.sub(copy.textFirstLine, string.find(copy.textFirstLine, " ") + 1)
+							table.insert(allBagItems, copy)
+							allBagItems[copy] = copy
 						end
 
 					end
@@ -440,9 +445,9 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 
 	-- sort all items alphabetically
 	table.sort(allBagItems, function(item1, item2)
-		return item1.originalTextFirstLine < item2.originalTextFirstLine
+		return item1.textFirstLine < item2.textFirstLine
 	end)
-	
+
 	-- all items menu item
 	do
 		local allItemsMenuItemName = "all items"

--- a/SkuCore/LocalMenu.lua
+++ b/SkuCore/LocalMenu.lua
@@ -294,7 +294,6 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 							if not tBagResults[bagId] then
 
 								local bagName = L["Bag"] .. " " .. bagId
-								local tText, tFullText = L["Bag"].." "..bagId, ""
 								table.insert(aParentChilds, bagName)
 								aParentChilds[bagName] = {
 									frameName = containerFrameName,
@@ -312,7 +311,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 						end
 
 						local bagItemSlotName = L["Bag"] .. bagId .. "-" .. slotId
-						local tText, tFullText = L["Empty"], ""
+						local tText = L["Empty"]
 						if containerFrame:IsEnabled() == true then
 							aParentChilds[bagItemSlotName] = {
 								frameName = containerFrameName,
@@ -463,13 +462,12 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 
 
 	local tFriendlyName = L["Bags"]
-	local tText, tFullText = L["Bags"], ""
 	table.insert(aParentChilds, tFriendlyName)
 	aParentChilds[tFriendlyName] = {
-		frameName = tFrameName,
+		frameName = nil,
 		RoC = "Child",
 		type = "Button",
-		obj = _G[tFrameName],
+		obj = nil,
 		textFirstLine = tFriendlyName,
 		textFull = "",
 		noMenuNumbers = true,
@@ -484,8 +482,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 	for x = 1, (#dtc - 1) do
 		if dtc[x] then
 
-			local tFriendlyName = L["Bag-slot"].." "..(x + 1)
-			local tText, tFullText = L["Bag-slot"].." "..(x + 1), ""
+			local tFriendlyName = L["Bag-slot"] .. " " .. (x + 1)
 			if dtc[x]:IsEnabled() == true then
 				aParentChilds[tFriendlyName] = {
 					frameName = L["Bag-slot"]..(x + 1),

--- a/SkuCore/LocalMenu.lua
+++ b/SkuCore/LocalMenu.lua
@@ -312,6 +312,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 
 						local bagItemSlotName = L["Bag"] .. bagId .. "-" .. slotId
 						local tText = L["Empty"]
+						local isEmpty = true
 						if containerFrame:IsEnabled() == true then
 							aParentChilds[bagItemSlotName] = {
 								frameName = containerFrameName,
@@ -343,6 +344,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 							local maybeText = getItemTooltipTextFromBagItem(bagItemButton.obj:GetParent():GetID(), bagItemButton.obj:GetID())
 							if maybeText then
 									local tText = maybeText
+								isEmpty = false
 									
 								if bagItemButton.obj.info then
 									if bagItemButton.obj.info.id then
@@ -379,6 +381,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 									if TooltipLines_helper(GameTooltip:GetRegions()) ~= "" then
 										local tText = unescape(TooltipLines_helper(GameTooltip:GetRegions()))
 										bagItemButton.textFirstLine, bagItemButton.textFull = ItemName_helper(tText)
+										isEmpty = false
 									end
 								end
 							end
@@ -387,10 +390,8 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 
 							if _G[containerFrameName .. "Count"] and not containerFrame.info then
 								if bagItemButton and _G[containerFrameName .. "Count"]:GetText() then
-									if not string.find(bagItemButton.textFirstLine, L["Empty"] .. " ") then
+									if not isEmpty then
 										bagItemButton.textFirstLine = bagItemButton.textFirstLine .. " " .. _G[containerFrameName .. "Count"]:GetText()
-									else
-										bagItemButton.textFirstLine = bagItemButton.textFirstLine
 									end
 								end
 							end
@@ -408,10 +409,8 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 								if not containerFrame.info.count then
 									bagItemButton.textFirstLine = bagItemButton.textFirstLine
 								else
-									if not string.find(bagItemButton.textFirstLine, L["Empty"] .. " ") and containerFrame.info.count > 1 then
+									if not isEmpty and containerFrame.info.count > 1 then
 										bagItemButton.textFirstLine = bagItemButton.textFirstLine .. " " .. containerFrame.info.count
-									else
-										bagItemButton.textFirstLine = bagItemButton.textFirstLine
 									end
 								end								
 							end							
@@ -420,7 +419,7 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 						
 						table.insert(tBagResultsByBag[bagId].childs, aParentChilds[bagItemSlotName])
 						-- if the item slot isn't empty, add it to allBagResults
-						if not string.find(aParentChilds[bagItemSlotName].textFirstLine, L["Empty"]) then
+						if not isEmpty then
 							-- create a copy that doesn't have the numbering in textFirstLine
 							copy = {}
 							for k, v in pairs(aParentChilds[bagItemSlotName]) do

--- a/SkuCore/LocalMenu.lua
+++ b/SkuCore/LocalMenu.lua
@@ -419,8 +419,10 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 						end
 						
 						table.insert(tBagResults[bagId].childs, aParentChilds[bagItemSlotName])
-						table.insert(allBagItems, aParentChilds[bagItemSlotName]	)
-						allBagItems[aParentChilds[bagItemSlotName]] = aParentChilds[bagItemSlotName]
+						if not string.find(aParentChilds[bagItemSlotName].textFirstLine, L["Empty"]) then
+							table.insert(allBagItems, aParentChilds[bagItemSlotName])
+							allBagItems[aParentChilds[bagItemSlotName]] = aParentChilds[bagItemSlotName]
+						end
 
 					end
 				end
@@ -443,7 +445,6 @@ function SkuCore:Build_BagnonInventoryFrame(aParentChilds)
 			RoC = "Child",
 			type = "Button",
 			textFirstLine = allItemsMenuItemName,
-			textFull = "",
 			noMenuNumbers = true,
 			childs = allBagItems,
 		}

--- a/locales/deDE.lua
+++ b/locales/deDE.lua
@@ -1388,3 +1388,5 @@ L["mining nodes"] = "bergbau"
 L["Questziel"] = "Questziel"
 
 L["Bereitschaft check"] = "Bereitschaft check"
+
+L["all items"] = "to do"

--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -1392,3 +1392,5 @@ L["mining nodes"] = "mining nodes"
 L["Questziel"] = "quest target"
 
 L["Bereitschaft check"] = "ready check"
+
+L["all items"] = "all items"


### PR DESCRIPTION
Note that there was a mix of spaces and tabs used for indentation in LocalMenu.lua, so I reindented it to use tabs only for consistency. Due to this, there is a ton of line changes that are just indentation changes. To filter these out when looking at the diff, please make sure to tick the "hide whitespace" option in diff options.

## Functional changes
- "all items" menu was added to bags, which lists all items alphabetically, with newly acquired items on top

## Refactoring changes
- deleted some unused vars (bunch of tText and tTextFull)
- replaced some undefined vars with nil
- factored out some code duplication
- made some variable names more specific (e.g. renamed tFriendlyName in different instances)

The last point I was doing when I was initially trying to understand the code. The same var name being used in different contexts (tFriendlyName specifically) made it hard to keep in mind to what it was referring to in a given context.
Renaming vars called "tFriendlyName" to something more specific for its given context made the code easier to read. Since, this might aid other devs in the future as well, I kept that refactoring there.

## Known bugs
- for some reason, "new" is prepended twice to the beginning of new items

## Remaining effort
- german translation for "all items"

#### commit messages

- Extract out containerFrame var
- Reindent LocalMenu.lua with only tabs
- Rename tFriendlyName to bagName
- Rename tFriendlyName to bagItemSlotName
- Simplify appending bag result
- Implement all items menu
- Filter out empty from all items view
- Sort all items view alphabetically
- Remove manual numbering in all items bag view
- Remove unused or undefined variables
- Clarify bag result variable names
- Show newly acquired items first
- Fix items like "empty vial" being filtered out
- Add "all items" to locale strings
