### PR TITLE
use wp reached range setting for single WP

### DIFF
--- a/SkuNav/Core.lua
+++ b/SkuNav/Core.lua
@@ -1646,7 +1646,7 @@ function SkuNav:ProcessCheckReachingWp()
 				--not rt recording/following, just a single wp
 				local distance = SkuNav:GetDistanceToWp(SkuOptions.db.profile[MODULE_NAME].selectedWaypoint)
 				if distance then
-					if distance < SkuNavWpSize[tWpObject.size] and SkuOptions.db.profile[MODULE_NAME].selectedWaypoint ~= "" then
+					if distance < SkuNavWpSize[tWpObject.size] + SkuNav.CurrentStandardWpReachedRange and SkuOptions.db.profile[MODULE_NAME].selectedWaypoint ~= "" then
 						SkuNav:PlayWpComments(SkuOptions.db.profile[MODULE_NAME].selectedWaypoint)
 						SkuOptions.Voice:OutputString("sound-success2", true, true, 0.3)
 						SkuOptions:VocalizeMultipartString(L["Arrived;at;waypoint"], false, true, 0.3, true)


### PR DESCRIPTION
Very small fix for what I see to be a bug. Might not even be worth mentioning in release notes.

Basically, after discovering I can manually control the wp reached range with ctrl shift Q, it really transformed my experience. I always toggle this manually between 1 and 3 meters and it makes navigation so much smoother compared to it being set to auto, although this is only since now I am quite experienced with routes and the navigation system in genral.

I did notice that the setting isn't taken into account when the beacon is just set to a single WP. The reason why this is a bit annoying is when I am farming a mob for some quest, I want to quickly mark off nearby waypoints as visited. For this I usually just start a route for a single waypoint through shift F9 menu. Since, here I just want to mark it off as visited and dont care about reaching the exact point, the fact a single waypoint route *always* uses 1 meter precision, regardless of what wp reached range is currently set to, makes this a bit frustrating sometimes.

So, this is just so the setting is taken into account for single waypoints as well and makes this use case much better.