### PR TITLE
Exclude specialized bags from count of free slots

### DIFF
--- a/SkuZOptions/Core.lua
+++ b/SkuZOptions/Core.lua
@@ -567,9 +567,11 @@ function SkuOptions:UpdateOverviewText()
 	--bag space
 	local tFreeCount = 0
 	for x = 0, 4 do
-		local t = GetContainerFreeSlots(x)
-		if t then
-			tFreeCount = tFreeCount + #t
+		local numFreeSlots, bagType = GetContainerNumFreeSlots(x)
+		-- only count general unspecialized bags
+		-- for available bag types see https://wowwiki-archive.fandom.com/wiki/ItemFamily							q
+		if bagType == 0 then
+			tFreeCount = tFreeCount + numFreeSlots
 		end
 	end
 	tGeneral = tGeneral.."\r\n"..L["Freie Taschenplätze: "]..tFreeCount


### PR DESCRIPTION
When calculating number of total free slots for the overview page, currently free slots for specialized containers like quivers are counted as well. This can make the displayed free slots misleading, because the player might think they still have enough space to loot, but actually can't because only specialized slots are left.

This change makes it so only general unspecialized bags are counted, since players probably just use free slots to check if they still have room for general loot.

This change could be further enhanced by listing free slots per bag type (if a player has specialized slots as well). For example a hunter with a quiver and an herbalism bag could have their free slots listed as:

3 empty general slots, 5 empty quiver slots, and 2 free herbalism slots

The further enhancement is just a thought. I didn't implement it because of the added effort. Perhaps if it seemed that would be something players would generally enjoy, I could implement it as part of a subsequent PR.

I tested this feature using 4 regular bags and a quiver. I also tested the edge case when there are empty bag slots. Seems to work fine 