### PR TITLE
Fix evaluate for boolean aura attributes

### DIFF
--- a/SkuAuras/data.lua
+++ b/SkuAuras/data.lua
@@ -1155,9 +1155,8 @@ SkuAuras.attributes = {
       friendlyName = L["Im Kampf"],
       evaluate = function(self, aEventData, aOperator, aValue)
       	--dprint("    ","SkuAuras.attributes.tInCombat.evaluate", aEventData.tInCombat, aOperator, true)
-         if aEventData.tInCombat then
-            return SkuAuras:ProcessEvaluate(aEventData.tInCombat, aOperator,true)
-         end
+         local tInCombat = aEventData.tInCombat and "true" or "false"
+         return SkuAuras:ProcessEvaluate(tInCombat, aOperator, aValue)
       end,
       values = {
          "true",

--- a/SkuAuras/data.lua
+++ b/SkuAuras/data.lua
@@ -65,9 +65,6 @@ end
 
 ------------------------------------------------------------------------------------------------------------------
 function SkuAuras:RemoveTags(aValue)
-   if not aValue then
-      return
-   end
    if type(aValue) ~= "string" then
       return aValue
    end
@@ -957,11 +954,6 @@ end
 SkuAuras.values = {
 }
 
-local function evaluateBool(bool, operator, value)
-   local attributeValue = bool and "true" or "false"
-         return SkuAuras:ProcessEvaluate(attributeValue, operator, value)
-end
-
 ------------------------------------------------------------------------------------------------------------------
 SkuAuras.attributes = {
    action = {
@@ -1160,7 +1152,7 @@ SkuAuras.attributes = {
       friendlyName = L["Im Kampf"],
       evaluate = function(self, aEventData, aOperator, aValue)
          --dprint("    ","SkuAuras.attributes.tInCombat.evaluate", aEventData.tInCombat, aOperator, true)
-         return evaluateBool(aEventData.tInCombat, aOperator, aValue)
+         return SkuAuras:ProcessEvaluate(aEventData.tInCombat, aOperator, aValue == "true")
       end,
       values = {
          "true",
@@ -1172,7 +1164,7 @@ SkuAuras.attributes = {
       friendlyName = L["Quell Einheit angreifbar"],
       evaluate = function(self, aEventData, aOperator, aValue)
          --dprint("    ","SkuAuras.attributes.tSourceUnitIDCannAttack.evaluate", aEventData.tSourceUnitIDCannAttack, aOperator, true)
-         return evaluateBool(aEventData.tSourceUnitIDCannAttack, aOperator, aValue)
+         return SkuAuras:ProcessEvaluate(aEventData.tSourceUnitIDCannAttack, aOperator, aValue == "true")
       end,
       values = {
          "true",
@@ -1184,7 +1176,7 @@ SkuAuras.attributes = {
       friendlyName = L["Ziel Einheit angreifbar"],
       evaluate = function(self, aEventData, aOperator, aValue)
          --dprint("    ","SkuAuras.attributes.tDestinationUnitIDCannAttack.evaluate", aEventData.tDestinationUnitIDCannAttack, aOperator, true)
-         return evaluateBool(aEventData.tDestinationUnitIDCannAttack, aOperator, aValue)
+         return SkuAuras:ProcessEvaluate(aEventData.tDestinationUnitIDCannAttack, aOperator, aValue == "true")
       end,
       values = {
          "true",
@@ -2072,8 +2064,8 @@ SkuAuras.Operators = {
       tooltip = L["Gewähltes Attribut entspricht dem gewählten Wert"],
       friendlyName = L["gleich"],
       func = function(aValueA, aValueB) 
-      	--dprint("      ","SkuAuras.Operators is", aValueA, aValueB)
-         if not aValueA or not aValueB then return false end
+         --dprint("      ","SkuAuras.Operators is", aValueA, aValueB)
+         if aValueA == nil or aValueB == nil then return false end
          --if type(aValueA) == "table" then return false end
          --dprint("type", type(aValueA))
          if type(aValueA) == "table" then 
@@ -2108,8 +2100,8 @@ SkuAuras.Operators = {
       tooltip = L["Gewähltes Attribut entspricht nicht dem gewählten Wert"],
       friendlyName = L["ungleich"],
       func = function(aValueA, aValueB) 
-      	----dprint("      ","SkuAuras.Operators isNot", aValueA, aValueB)
-         if not aValueA or not aValueB then return false end
+         ----dprint("      ","SkuAuras.Operators isNot", aValueA, aValueB)
+         if aValueA == nil or aValueB == nil then return false end
          --if type(aValueA) == "table" then return false end
          if type(aValueA) == "table" then 
             for tName, tValue in pairs(aValueA) do

--- a/SkuAuras/data.lua
+++ b/SkuAuras/data.lua
@@ -957,6 +957,11 @@ end
 SkuAuras.values = {
 }
 
+local function evaluateBool(bool, operator, value)
+   local attributeValue = bool and "true" or "false"
+         return SkuAuras:ProcessEvaluate(attributeValue, operator, value)
+end
+
 ------------------------------------------------------------------------------------------------------------------
 SkuAuras.attributes = {
    action = {
@@ -1154,9 +1159,8 @@ SkuAuras.attributes = {
       tooltip = L["Ob das Event im Kampf auftritt"],
       friendlyName = L["Im Kampf"],
       evaluate = function(self, aEventData, aOperator, aValue)
-      	--dprint("    ","SkuAuras.attributes.tInCombat.evaluate", aEventData.tInCombat, aOperator, true)
-         local tInCombat = aEventData.tInCombat and "true" or "false"
-         return SkuAuras:ProcessEvaluate(tInCombat, aOperator, aValue)
+         --dprint("    ","SkuAuras.attributes.tInCombat.evaluate", aEventData.tInCombat, aOperator, true)
+         return evaluateBool(aEventData.tInCombat, aOperator, aValue)
       end,
       values = {
          "true",
@@ -1167,10 +1171,8 @@ SkuAuras.attributes = {
       tooltip = L["Ob die Quell-Einheit, für die Aura ausgelöst wird, angreifbar ist"],
       friendlyName = L["Quell Einheit angreifbar"],
       evaluate = function(self, aEventData, aOperator, aValue)
-      	--dprint("    ","SkuAuras.attributes.tSourceUnitIDCannAttack.evaluate", aEventData.tSourceUnitIDCannAttack, aOperator, true)
-         if aEventData.tSourceUnitIDCannAttack then
-            return SkuAuras:ProcessEvaluate(aEventData.tSourceUnitIDCannAttack, aOperator,true)
-         end
+         --dprint("    ","SkuAuras.attributes.tSourceUnitIDCannAttack.evaluate", aEventData.tSourceUnitIDCannAttack, aOperator, true)
+         return evaluateBool(aEventData.tSourceUnitIDCannAttack, aOperator, aValue)
       end,
       values = {
          "true",
@@ -1181,10 +1183,8 @@ SkuAuras.attributes = {
       tooltip = L["Ob die Ziel-Einheit, für die Aura ausgelöst wird, angreifbar ist"],
       friendlyName = L["Ziel Einheit angreifbar"],
       evaluate = function(self, aEventData, aOperator, aValue)
-      	--dprint("    ","SkuAuras.attributes.tDestinationUnitIDCannAttack.evaluate", aEventData.tDestinationUnitIDCannAttack, aOperator, true)
-         if aEventData.tDestinationUnitIDCannAttack then
-            return SkuAuras:ProcessEvaluate(aEventData.tDestinationUnitIDCannAttack, aOperator,true)
-         end
+         --dprint("    ","SkuAuras.attributes.tDestinationUnitIDCannAttack.evaluate", aEventData.tDestinationUnitIDCannAttack, aOperator, true)
+         return evaluateBool(aEventData.tDestinationUnitIDCannAttack, aOperator, aValue)
       end,
       values = {
          "true",


### PR DESCRIPTION
#### Auras
* fix in combat, source unit attackable, and target unit attackable

I noticed there were issues with the "in combat" aura attribute, because any aura with it would never trigger. Looking in code I found it is because the `SkuAuras:RemoveTags` function can't handle booleans. So here is just a minor fix to make it work again.

Then I found 2 other boolean attributes with same logic and so updated them as well. Tested all 3 attributes after change and working fine.