### PR TITLE
Don't override spell name/ item name from condition value

### DIFF
--- a/SkuAuras/Core.lua
+++ b/SkuAuras/Core.lua
@@ -846,25 +846,6 @@ if tEventData[2] ~= "KEY_PRESS" then
 
 			tEvaluateData.class = nil
 
-			--add spell name and item name from condition values to data for output if there are no value from eventdata
-			local tAttributesWithSpellNameData = {
-				--["spellName"] = true,
-				["spellNameOnCd"] = true,
-				["buffListTarget"] = true,
-				["debuffListTarget"] = true,
-			}
-			local tAttributesWithItemNameData = {
-				["itemName"] = true,
-			}
-			for tAttributeName, tAttributeValue in pairs(tAuraData.attributes) do
-				if tAttributesWithSpellNameData[tAttributeName] then
-					tEvaluateData.spellName = SkuAuras:RemoveTags(tAttributeValue[1][2])
-				end
-				if tAttributesWithItemNameData[tAttributeName] then
-					--tEvaluateData.itemName = SkuAuras:RemoveTags(tAttributeValue[1][2])
-				end
-			end
-
 			--evaluate attributes
 			local tSingleBuffListTargetValue
 			local tSingleDebuffListTargetValue


### PR DESCRIPTION
There is this behavior when evaluating auras that gets in the way of creating some useful auras and I am unsure whether it really isn't more harmful than helpful. Maybe there is some use case for it that I am missing, so you might help me understand, but otherwise I am proposing removing it for reasons I will explain.

Basically, right before auras are evaluated, if there is any condition, where the right hand side is a spell name, then the spellName for the event is overridden with that value. So for example take an aura like:

if buff list target (l) contains mark of the wild ...

⦁	then whenever that aura is evaluated, the spell name attribute will be mark of the wild. One issue is that this prevents being able to create some useful auras, like lets say I want an aura that triggers whenever I cast a spell and my target has a particular buff/debuff. Normally I would create an aura like:

if buff list (l) contains mark of the wild and event equal spell successful and spell name equal healing touch then ...

But since the spell name attribute will be overridden to always be mark of the wild, this aura can't work.

I am also unsure when this behavior of overriding spell name is useful, since it turns the spell name attribute into a constant for a given aura, because for any given aura that has one of these conditions like buff list target, spell name will always be the same for any evaluation. For example, for above aura, spell name will always be mark of the wild, no matter what is happening. Since I understand that attributes (left hand side) should be variable for events, and the right hand side values are supposed to be constant. But this effectively turns the left hand side into a constant, so then including a spell name condition is just comparing a constant to a constant.

An alternative to removing it completely, would be to only override the spell name in case the event data doesn't already have spell name defined. In that case, the above aura would work as expected. But even so, I am not able to think of a use case for this behavior since it still turns spell name into a constant value, so I just propose removing it.
