### PR TITLE
Use guid for best unit

### DIFF
--- a/SkuAuras/Core.lua
+++ b/SkuAuras/Core.lua
@@ -160,7 +160,8 @@ function SkuAuras:GetBestUnitId(aUnitGUID, aReturnAll)
 	end
 	checkUnit("target")
 	checkUnit("player")
-
+	checkUnit("pet")
+	
 	if aReturnAll then
 		return tUnitIds
 	end

--- a/SkuAuras/Core.lua
+++ b/SkuAuras/Core.lua
@@ -636,6 +636,8 @@ function SkuAuras:EvaluateAllAuras(tEventData)
 	--build non event related data to evaluate
 	local tSourceUnitID = SkuAuras:GetBestUnitId(tEventData[CleuBase.sourceGUID])
 	local tDestinationUnitID = SkuAuras:GetBestUnitId(tEventData[CleuBase.destGUID])
+	
+	local tDestinationUnitIDCannAttack
 	if tDestinationUnitID and tDestinationUnitID[1] then
 		if tDestinationUnitID ~= "party0" then
 			tDestinationUnitIDCannAttack = UnitCanAttack("player", tDestinationUnitID[1])
@@ -647,6 +649,7 @@ function SkuAuras:EvaluateAllAuras(tEventData)
 		tTargetTargetUnitId = SkuAuras:GetBestUnitId(UnitGUID("playertargettarget"))
 	end
 
+	local tSourceUnitIDCannAttack
 	if tSourceUnitID and tSourceUnitID[1] then
 		if tSourceUnitID ~= "party0" then
 			tSourceUnitIDCannAttack = UnitCanAttack("player", tSourceUnitID[1])

--- a/SkuAuras/Core.lua
+++ b/SkuAuras/Core.lua
@@ -127,19 +127,19 @@ function SkuAuras:OnDisable()
 end
 
 ---------------------------------------------------------------------------------------------------------------------------------------
-function SkuAuras:GetBestUnitId(aUnitName, aReturnAll)
+function SkuAuras:GetBestUnitId(aUnitGUID, aReturnAll)
 
-	if not aUnitName then
+	if not aUnitGUID then
 		if aReturnAll then return {} else return end
 	end
-	if aUnitName == "" then
+	if aUnitGUID == "" then
 		if aReturnAll then return {} else return end
 	end
 
 	local tUnitIds = {}
 
 	local function checkUnit(unit)
-		if aUnitName == UnitName(unit) then
+		if aUnitGUID == UnitGUID(unit) then
 			if not aReturnAll then
 				return unit
 			else
@@ -158,7 +158,7 @@ function SkuAuras:GetBestUnitId(aUnitName, aReturnAll)
 			checkUnit("party"..x)
 		end
 	end
-	if aUnitName == UnitName("player") and (UnitName("party1") or UnitName("raid1")) then
+	if aUnitGUID == UnitGUID("player") and (UnitName("party1") or UnitName("raid1")) then
 		if not aReturnAll then
 			return "party0"
 		else
@@ -392,22 +392,22 @@ function SkuAuras:UNIT_TICKER(aUnitId)
 			SkuAuras.UnitRepo[tUnitId].unitPower = tPower
 		end
 
-		if SkuAuras.UnitRepo[tUnitId].unitTargetName ~= UnitGUID(tUnitId.."target") then
-			SkuAuras.UnitRepo[tUnitId].unitTargetName = UnitGUID(tUnitId.."target")
+		local unitTargetGUID = UnitGUID(tUnitId.."target")
+		if SkuAuras.UnitRepo[tUnitId].unitTargetName ~= unitTargetGUID then
+			SkuAuras.UnitRepo[tUnitId].unitTargetName = unitTargetGUID
 
 			--dprint("ooooooooooooooo target change for ", tUnitId)
 			--dprint("changed to", UnitName(tUnitId.."target"))
 			if UnitName(tUnitId.."target") then
-				local tNewTargetUnitId = SkuAuras:GetBestUnitId(UnitName(tUnitId.."target"))
 				local tEventData = {
 					GetTime(),
 					"UNIT_TARGETCHANGE",
 					nil,
-					tUnitId,
+					UnitGUID(tUnitId),
 					UnitName(tUnitId),
 					nil,
 					nil,
-					tNewTargetUnitId,
+					unitTargetGUID,
 					UnitName(tUnitId.."target"),
 					nil,
 					nil,
@@ -415,7 +415,6 @@ function SkuAuras:UNIT_TICKER(aUnitId)
 					nil,
 					nil,
 				}
-				tEventData[35] = SkuAuras.UnitRepo[tUnitId].unitHealth
 				SkuAuras:COMBAT_LOG_EVENT_UNFILTERED("customCLEU", tEventData)
 			end
 		end
@@ -428,11 +427,11 @@ function SkuAuras:UNIT_TICKER(aUnitId)
 				GetTime(),
 				"UNIT_HEALTH",
 				nil,
-				tUnitId,
+				UnitGUID(tUnitId),
 				UnitName(tUnitId),
 				nil,
 				nil,
-				tUnitId,
+				UnitGUID(tUnitId),
 				UnitName(tUnitId),
 				nil,
 				nil,
@@ -450,11 +449,11 @@ function SkuAuras:UNIT_TICKER(aUnitId)
 					GetTime(),
 					"UNIT_POWER",
 					nil,
-					tUnitId,
+					UnitGUID(tUnitId),
 					UnitName(tUnitId),
 					nil,
 					nil,
-					tUnitId,
+					UnitGUID(tUnitId),
 					UnitName(tUnitId),
 					nil,
 					nil,
@@ -475,11 +474,11 @@ function SkuAuras:UNIT_TICKER(aUnitId)
 					GetTime(),
 					"UNIT_POWER",
 					nil,
-					tUnitId,
+					UnitGUID(tUnitId),
 					UnitName(tUnitId),
 					nil,
 					nil,
-					tUnitId,
+					UnitGUID(tUnitId),
 					UnitName(tUnitId),
 					nil,
 					nil,
@@ -642,8 +641,8 @@ function SkuAuras:EvaluateAllAuras(tEventData)
 		SkuOptions.db.char[MODULE_NAME].Auras = {}
 	end
 	--build non event related data to evaluate
-	local tSourceUnitID = SkuAuras:GetBestUnitId(tEventData[CleuBase.sourceName], true)
-	local tDestinationUnitID = SkuAuras:GetBestUnitId(tEventData[CleuBase.destName], true)
+	local tSourceUnitID = SkuAuras:GetBestUnitId(tEventData[CleuBase.sourceGUID], true)
+	local tDestinationUnitID = SkuAuras:GetBestUnitId(tEventData[CleuBase.destGUID], true)
 	if tDestinationUnitID and tDestinationUnitID[1] then
 		if tDestinationUnitID ~= "party0" then
 			tDestinationUnitIDCannAttack = UnitCanAttack("player", tDestinationUnitID[1])
@@ -652,7 +651,7 @@ function SkuAuras:EvaluateAllAuras(tEventData)
 
 	local tTargetTargetUnitId = {}
 	if UnitName("playertargettarget") then
-		tTargetTargetUnitId = SkuAuras:GetBestUnitId(UnitName("playertargettarget"), true)
+		tTargetTargetUnitId = SkuAuras:GetBestUnitId(UnitGUID("playertargettarget"), true)
 	end
 
 	if tSourceUnitID and tSourceUnitID[1] then

--- a/SkuAuras/Core.lua
+++ b/SkuAuras/Core.lua
@@ -138,26 +138,24 @@ function SkuAuras:GetBestUnitId(aUnitName, aReturnAll)
 
 	local tUnitIds = {}
 
+	local function checkUnit(unit)
+		if aUnitName == UnitName(unit) then
+			if not aReturnAll then
+				return unit
+			else
+				tUnitIds[#tUnitIds + 1] = unit
+			end
+		end
+	end
+
 	if IsInRaid() then
 		for x = 1, 40 do 
-			if aUnitName == UnitName("raid"..x) then
-				if not aReturnAll then
-					return "raid"..x
-				else
-					tUnitIds[#tUnitIds + 1] = "raid"..x
-				end
-			end
+			checkUnit("raid"..x)
 		end
 	end
 	if IsInGroup() then
 		for x = 1, 4 do 
-			if aUnitName == UnitName("party"..x) then
-				if not aReturnAll then
-					return "party"..x
-				else
-					tUnitIds[#tUnitIds + 1] = "party"..x
-				end
-			end
+			checkUnit("party"..x)
 		end
 	end
 	if aUnitName == UnitName("player") and (UnitName("party1") or UnitName("raid1")) then
@@ -167,20 +165,8 @@ function SkuAuras:GetBestUnitId(aUnitName, aReturnAll)
 			tUnitIds[#tUnitIds + 1] = "party0"
 		end
 	end
-	if aUnitName== UnitName("target") then
-		if not aReturnAll then
-			return "target"
-		else
-			tUnitIds[#tUnitIds + 1] = "target"
-		end
-	end
-	if aUnitName == UnitName("player") then
-		if not aReturnAll then
-			return "player"
-		else
-			tUnitIds[#tUnitIds + 1] = "player"
-		end
-	end
+	checkUnit("target")
+	checkUnit("player")
 
 	if aReturnAll then
 		return tUnitIds

--- a/SkuAuras/Core.lua
+++ b/SkuAuras/Core.lua
@@ -127,37 +127,33 @@ function SkuAuras:OnDisable()
 end
 
 ---------------------------------------------------------------------------------------------------------------------------------------
-function SkuAuras:GetBestUnitId(aUnitGUID, aReturnAll)
+function SkuAuras:GetBestUnitId(aUnitGUID)
 
 	if not aUnitGUID then
-		if aReturnAll then return {} else return end
+		return {}
 	end
 	if aUnitGUID == "" then
-		if aReturnAll then return {} else return end
+		return {}
 	end
 
 	local tUnitIds = {}
 
 	local function checkUnit(unit)
 		if aUnitGUID == UnitGUID(unit) then
-			if not aReturnAll then
-				return unit
-			else
-				tUnitIds[#tUnitIds + 1] = unit
-			end
+			tUnitIds[#tUnitIds + 1] = unit
 		end
 	end
 
 	if IsInRaid() then
-		for x = 1, 40 do 
-			checkUnit("raid"..x)
+		for x = 1, 40 do
+			checkUnit("raid" .. x)
 		end
 	end
 	if IsInGroup() then
 		checkUnit("party0")
-		for x = 1, 4 do 
-			checkUnit("party"..x)
-			checkUnit("party"..x.."target")
+		for x = 1, 4 do
+			checkUnit("party" .. x)
+			checkUnit("party" .. x .. "target")
 		end
 	end
 	checkUnit("target")
@@ -166,10 +162,8 @@ function SkuAuras:GetBestUnitId(aUnitGUID, aReturnAll)
 	checkUnit("focus")
 	checkUnit("focustarget")
 	checkUnit("targettarget")
-	
-	if aReturnAll then
-		return tUnitIds
-	end
+
+	return tUnitIds
 end
 
 ---------------------------------------------------------------------------------------------------------------------------------------
@@ -640,8 +634,8 @@ function SkuAuras:EvaluateAllAuras(tEventData)
 		SkuOptions.db.char[MODULE_NAME].Auras = {}
 	end
 	--build non event related data to evaluate
-	local tSourceUnitID = SkuAuras:GetBestUnitId(tEventData[CleuBase.sourceGUID], true)
-	local tDestinationUnitID = SkuAuras:GetBestUnitId(tEventData[CleuBase.destGUID], true)
+	local tSourceUnitID = SkuAuras:GetBestUnitId(tEventData[CleuBase.sourceGUID])
+	local tDestinationUnitID = SkuAuras:GetBestUnitId(tEventData[CleuBase.destGUID])
 	if tDestinationUnitID and tDestinationUnitID[1] then
 		if tDestinationUnitID ~= "party0" then
 			tDestinationUnitIDCannAttack = UnitCanAttack("player", tDestinationUnitID[1])
@@ -650,7 +644,7 @@ function SkuAuras:EvaluateAllAuras(tEventData)
 
 	local tTargetTargetUnitId = {}
 	if UnitName("playertargettarget") then
-		tTargetTargetUnitId = SkuAuras:GetBestUnitId(UnitGUID("playertargettarget"), true)
+		tTargetTargetUnitId = SkuAuras:GetBestUnitId(UnitGUID("playertargettarget"))
 	end
 
 	if tSourceUnitID and tSourceUnitID[1] then

--- a/SkuAuras/Core.lua
+++ b/SkuAuras/Core.lua
@@ -154,13 +154,18 @@ function SkuAuras:GetBestUnitId(aUnitGUID, aReturnAll)
 		end
 	end
 	if IsInGroup() then
-		for x = 0, 4 do 
+		checkUnit("party0")
+		for x = 1, 4 do 
 			checkUnit("party"..x)
+			checkUnit("party"..x.."target")
 		end
 	end
 	checkUnit("target")
 	checkUnit("player")
 	checkUnit("pet")
+	checkUnit("focus")
+	checkUnit("focustarget")
+	checkUnit("targettarget")
 	
 	if aReturnAll then
 		return tUnitIds

--- a/SkuAuras/Core.lua
+++ b/SkuAuras/Core.lua
@@ -138,6 +138,7 @@ function SkuAuras:GetBestUnitId(aUnitName, aReturnAll)
 
 	local tUnitIds = {}
 
+	if IsInRaid() then
 		for x = 1, 40 do 
 			if aUnitName == UnitName("raid"..x) then
 				if not aReturnAll then
@@ -147,6 +148,8 @@ function SkuAuras:GetBestUnitId(aUnitName, aReturnAll)
 				end
 			end
 		end
+	end
+	if IsInGroup() then
 		for x = 1, 4 do 
 			if aUnitName == UnitName("party"..x) then
 				if not aReturnAll then
@@ -156,27 +159,28 @@ function SkuAuras:GetBestUnitId(aUnitName, aReturnAll)
 				end
 			end
 		end
-		if aUnitName == UnitName("player") and (UnitName("party1") or UnitName("raid1")) then
-			if not aReturnAll then
-				return "party0"
-			else
-				tUnitIds[#tUnitIds + 1] = "party0"
-			end
+	end
+	if aUnitName == UnitName("player") and (UnitName("party1") or UnitName("raid1")) then
+		if not aReturnAll then
+			return "party0"
+		else
+			tUnitIds[#tUnitIds + 1] = "party0"
 		end
-		if aUnitName== UnitName("target") then
-			if not aReturnAll then
-				return "target"
-			else
-				tUnitIds[#tUnitIds + 1] = "target"
-			end
+	end
+	if aUnitName== UnitName("target") then
+		if not aReturnAll then
+			return "target"
+		else
+			tUnitIds[#tUnitIds + 1] = "target"
 		end
-		if aUnitName == UnitName("player") then
-			if not aReturnAll then
-				return "player"
-			else
-				tUnitIds[#tUnitIds + 1] = "player"
-			end
+	end
+	if aUnitName == UnitName("player") then
+		if not aReturnAll then
+			return "player"
+		else
+			tUnitIds[#tUnitIds + 1] = "player"
 		end
+	end
 
 	if aReturnAll then
 		return tUnitIds

--- a/SkuAuras/Core.lua
+++ b/SkuAuras/Core.lua
@@ -154,15 +154,8 @@ function SkuAuras:GetBestUnitId(aUnitGUID, aReturnAll)
 		end
 	end
 	if IsInGroup() then
-		for x = 1, 4 do 
+		for x = 0, 4 do 
 			checkUnit("party"..x)
-		end
-	end
-	if aUnitGUID == UnitGUID("player") and (UnitName("party1") or UnitName("raid1")) then
-		if not aReturnAll then
-			return "party0"
-		else
-			tUnitIds[#tUnitIds + 1] = "party0"
 		end
 	end
 	checkUnit("target")

--- a/SkuAuras/Core.lua
+++ b/SkuAuras/Core.lua
@@ -628,6 +628,12 @@ function SkuAuras:ProcessEvaluate(aValueA, aOperator, aValueB)
 	return SkuAuras.Operators[aOperator].func(aValueA, aValueB)
 end
 
+local CombatLogFilterAttackable =  bit.bor(
+	COMBATLOG_FILTER_HOSTILE_UNITS,
+	COMBATLOG_FILTER_HOSTILE_PLAYERS,
+	COMBATLOG_FILTER_NEUTRAL_UNITS
+)
+
 ---------------------------------------------------------------------------------------------------------------------------------------
 function SkuAuras:EvaluateAllAuras(tEventData)
 	if not SkuOptions.db.char[MODULE_NAME].Auras then
@@ -642,6 +648,8 @@ function SkuAuras:EvaluateAllAuras(tEventData)
 		if tDestinationUnitID ~= "party0" then
 			tDestinationUnitIDCannAttack = UnitCanAttack("player", tDestinationUnitID[1])
 		end
+	elseif tEventData[CleuBase.destFlags] then
+		tDestinationUnitIDCannAttack = CombatLog_Object_IsA(tEventData[CleuBase.destFlags], CombatLogFilterAttackable)
 	end
 
 	local tTargetTargetUnitId = {}
@@ -654,6 +662,8 @@ function SkuAuras:EvaluateAllAuras(tEventData)
 		if tSourceUnitID ~= "party0" then
 			tSourceUnitIDCannAttack = UnitCanAttack("player", tSourceUnitID[1])
 		end
+	elseif tEventData[CleuBase.sourceFlags] then
+		tSourceUnitIDCannAttack = CombatLog_Object_IsA(tEventData[CleuBase.sourceFlags], CombatLogFilterAttackable)
 	end
 
 	local unitHealthOrPowerUpdate = tEventData[35] or tEventData[36]

--- a/SkuAuras/data.lua
+++ b/SkuAuras/data.lua
@@ -702,6 +702,10 @@ SkuAuras.valuesDefault = {
          tooltip = L["du selbst. Beispiel: Ein Buff, der auf dich gezaubert wurde"],
          friendlyName = L["selbst"],
       },
+      ["pet"] = {
+         tooltip = L["The player character's active pet"],
+         friendlyName = L["Your pet"],
+      },
       ["focus"] = {
          tooltip = L["dein fokus. Beispiel: Ein Buff, der auf deinen focus gezaubert wurde"],
          friendlyName = L["fokus"],
@@ -1108,6 +1112,28 @@ local zeroToOneHundred = {
            
 }
 
+local unitIDValues = {
+   "target",
+   "player",
+   "pet",
+   "party",
+   "partyWoPlayer",
+   "all",
+   "focus",
+   "party0",
+   "party1",
+   "party2",
+   "party3",
+   "party4",
+   "targettarget",
+   "focustarget",
+   "party0target",
+   "party1target",
+   "party2target",
+   "party3target",
+   "party4target",
+}
+
 ------------------------------------------------------------------------------------------------------------------
 SkuAuras.attributes = {
    action = {
@@ -1187,27 +1213,7 @@ SkuAuras.attributes = {
             end
          end
       end,
-      values = {
-         "target",
-         "player",
-         "party",
-         "partyWoPlayer",
-         "all",
-         "focus",
-         "party0",
-         "party1",
-         "party2",
-         "party3",
-         "party4",
-         "targettarget",
-         "focustarget",
-         "party0target",
-         "party1target",
-         "party2target",
-         "party3target",
-         "party4target",
-         
-      },
+      values = unitIDValues,
    },
    targetTargetUnitId = {
       tooltip = L["Die Einheit des Ziels deines Ziels"],
@@ -1270,27 +1276,7 @@ SkuAuras.attributes = {
             end
          end
       end,
-      values = {
-         "target",
-         "player",
-         "party",
-         "partyWoPlayer",
-         "all",
-         "focus",
-         "party0",
-         "party1",
-         "party2",
-         "party3",
-         "party4",
-         "targettarget",
-         "focustarget",
-         "party0target",
-         "party1target",
-         "party2target",
-         "party3target",
-         "party4target",
-         
-      },
+      values = unitIDValues,
    },   
    pressedKey = {
       tooltip = L["Welche Taste das Ereignis ausgelöst hat"],
@@ -1424,27 +1410,7 @@ SkuAuras.attributes = {
             end
          end
       end,
-      values = {
-         "target",
-         "player",
-         "party",
-         "partyWoPlayer",
-         "all",
-         "focus",
-         "party0",
-         "party1",
-         "party2",
-         "party3",
-         "party4",
-         "targettarget",
-         "focustarget",
-         "party0target",
-         "party1target",
-         "party2target",
-         "party3target",
-         "party4target",
-         
-      },
+      values = unitIDValues,
    },
    event = {
       tooltip = L["Das Ereignis, das die Aura auslösen soll"],

--- a/locales/deDE.lua
+++ b/locales/deDE.lua
@@ -981,6 +981,8 @@ L["dein aktuelles Ziel. Beispiel: Ein Debuff, der auf deinem aktuelle Ziel ausge
 L["dein ziel"] = "dein ziel"
 L["du selbst. Beispiel: Ein Buff, der auf dich gezaubert wurde"] = "du selbst. Beispiel: Ein Buff, der auf dich gezaubert wurde"
 L["selbst"] = "selbst"
+L["The player character's active pet"] = "to do!!!" -- aura value tooltip
+L["Your pet"] = "to do!!!" -- aura value friendly name
 L["dein fokus. Beispiel: Ein Buff, der auf deinen focus gezaubert wurde"] = "dein fokus. Beispiel: Ein Buff, der auf deinen focus gezaubert wurde"
 L["fokus"] = "fokus"
 L["ein beliebiges Gruppenmitglied. Beispiel: Ein Buff, der auf einem Gruppenmitglied ausgelaufen ist"] = "ein beliebiges Gruppenmitglied. Beispiel: Ein Buff, der auf einem Gruppenmitglied ausgelaufen ist"

--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -981,6 +981,8 @@ L["dein aktuelles Ziel. Beispiel: Ein Debuff, der auf deinem aktuelle Ziel ausge
 L["dein ziel"]  = "your target" --
 L["du selbst. Beispiel: Ein Buff, der auf dich gezaubert wurde"]  = "yourself. Example: A buff that was cast on you" --
 L["selbst"]  = "yourself" --
+L["The player character's active pet"] = "The player character's active pet" -- aura value tooltip
+L["Your pet"] = "Your pet" -- aura value friendly name
 L["dein fokus. Beispiel: Ein Buff, der auf deinen focus gezaubert wurde"]  = "your focus. example: a buff cast on your focus target" --
 L["fokus"]  = "focus" --
 L["ein beliebiges Gruppenmitglied. Beispiel: Ein Buff, der auf einem Gruppenmitglied ausgelaufen ist"]  = "any party member. Example: A buff cast on a party member" --


### PR DESCRIPTION
#### Auras
* added the value "Your pet" to "Source (L)", "Target (L)", and "Target of yor target (L)"
* fixed "Source (L)", "Target (L)", and "Target of yor target (L)" sometimes giving false positives when there are multiple units with the same name
* "Source (L)", "Target (L)", and "Target of yor target (L)" should now work with all available values
* "source unit attackable" and "target unit attackable" should now be available for all events

##### added the value "Your pet" to "Source (L)", "Target (L)", and "Target of yor target (L)"
This change was very straightforward. Just made it so "pet" is also checked in `GetBestUnitId` and added the tooltip and friendly name for the new value. This is something I found missing for some time playing a hunter and allows creating auras to check if my pet was targetted, if my pet cast a spell, if my pet received  a debuff, how much damage my pet does, and so on

There are 2 new strings that would need to be translated to german and I would appreciate the help again :)

##### fixed "Source (L)", "Target (L)", and "Target of yor target (L)" sometimes giving false positives when there are multiple units with the same name

As an example, imagine the scenario you have an aura set up for being alerted when your target starts casting a spell that is something like:

```if event equal spell_start and source (L) contains your target then audio output brang```

Then let's say you start fighting a mob with the generic name "Evil mage". At the same time there is another player fighting another mob also called "Evil mage". Their mob starts casting a spell. Since `GetBestUnitId` figures out if the source is your target by comparing the names, it can't tell the two mobs apart, the aura will trigger, and it gives the false impression that your target started casting the spell even though they didn't.

To solve this, I just changed `GetBestUnitId` to compare unit GUIDs instead of names, which should be unique. As part of that I also updated all custom events like "unit_health" to put the unit GUID in the sourceGUID and destGUID positions. That is what the combat log events have there and anyhow those fields weren't being used before these changes anyway so it shouldn't break anything.

In `GetBestUnitId`, I removed the `aReturnAll` parameter because it wasn't being used anywhere anymore and I extracted the common pattern so that I would need to make the UnitName -> UnitGUID change in only one place. But if you don't like how the function looks now then I am open to changing it.

I tested this over about 5 days now playing my level 72 hunter and level 61-62 druid. I have a bit over a dozen auras that use one of the unit id attributes and haven't noticed any regressions. They all seem to be working fine and I didn't see any more false positives. For source/target the auras use yourself, your target, party members, party member 1, and the new "your pet". For events they have spell_start, unit_health, _target changed, aura gained,, aura lost, and  spell success.

##### "Source (L)", "Target (L)", and "Target of yor target (L)" should now work with all available values

While working on this I also noticed that for "source/target contains unit" to work, the unit has to be checked in `GetBestUnitId`. So right now these attributes don't work with focus, focus target, target of your target, and party member 1-4 target because they aren't checked. So I added them to be checked and testing they now all work.

##### "source unit attackable" and "target unit attackable" should be now available for all events

I also noticed for these 2 attributes to work `GetBestUnitId` needs to return something. So with the previous change, these 2 started working in more scenarios. But I also noticed that you can figure out if something is attackable from the unit flags, so I added a fallback that if `GetBestUnitId` doesn't return anything (i.e. the unit has no relationship with the player that is directly checked) then it checks whether it is attackable from the flags.

Since `GetBestUnitId` always returns something for custom events and all combat log events give the flags, this means that these 2 attributes are now available for all events.

I tested by commenting out the norml way it is checked and just had it check using the flags fallback case, so I could compare if both methods return same results.

Testing whether this also works with passive units was very tricky, because as soon as you attack it, then it turns hostile, so it was hard to figure out how to have a passive unit be the source or target of an event without making it hostile. But I found that if I use hunter's mark it doesn't aggro, so it stays passive and is the target for an event. So that way was able to confirm that by using the neutral units filter that passive units are also correctly covered :)
